### PR TITLE
[Fix] 이미지 크기 오류 수정

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -29,8 +29,7 @@ const MainImage = styled.section`
 
   display: flex;
   justify-content: center;
-
-  overflow: scroll;
+  overflow: hidden;
 `;
 const Image = styled.img`
   width: calc(100vw - 12rem);


### PR DESCRIPTION
해결 방법:
스크롤바를 제거해 초기화면 이미지 좌우측에 스크롤바가 생기는 문제 해결
*flex-box를 사용해 초기화면 Container 컴포넌트 전체 크기가 viewport를 넘어가지 않으므로 스크롤바가 불필요