### PR TITLE
[Refactor] Diagnose Type을 API에 맞게 변경

### DIFF
--- a/src/data/answer_type.ts
+++ b/src/data/answer_type.ts
@@ -1,0 +1,13 @@
+export const ANSWER_TYPE = {
+  DEF: "DEF",
+  IMG: "IMG",
+  NUMBER_1: "NUMBER_1",
+  NUMBER_2: "NUMBER_2",
+  NUMBER_3: "NUMBER_3",
+  NUMBER_4: "NUMBER_4",
+  NUMBER_5: "NUMBER_5",
+  NUMBER_6: "NUMBER_6",
+  NUMBER_7: "NUMBER_7",
+  NUMBER_8: "NUMBER_8",
+  DRAG_1: "DRAG_1",
+} as const;

--- a/src/hooks/diagnose/useDiagnosis.ts
+++ b/src/hooks/diagnose/useDiagnosis.ts
@@ -4,6 +4,7 @@ import { IAnswer, IQuestion } from "src/interfaces/diagnoseApi/diagnosis";
 import { useAppDispatch } from "src/state";
 import { resetAnswer } from "src/state/answerSlice";
 import { DIAGNOSE_TYPE } from "src/utils/diagnosis";
+import { ANSWER_TYPE } from "src/data/answer_type";
 import useStomache from "./useStomache";
 
 function useDiagnosis(state: string) {
@@ -13,8 +14,10 @@ function useDiagnosis(state: string) {
   const [curQuestion, setCurQuestion] = useState<IQuestion>({
     id: 0,
     question: "",
-    answers: [],
     is_multiple: false,
+    image_url: null,
+    answer_type: ANSWER_TYPE.DEF,
+    answers: null,
   });
   const [selectedAnswer, setSelectedAnswer] = useState([] as IAnswer[]);
   const [loading, setLoading] = useState(false);

--- a/src/interfaces/diagnoseApi/answer.type.ts
+++ b/src/interfaces/diagnoseApi/answer.type.ts
@@ -1,0 +1,4 @@
+import { ANSWER_TYPE } from "src/data/answer_type";
+
+type TAnswerTypeKey = keyof typeof ANSWER_TYPE;
+export type TAnswerType = typeof ANSWER_TYPE[TAnswerTypeKey];

--- a/src/interfaces/diagnoseApi/diagnosis.ts
+++ b/src/interfaces/diagnoseApi/diagnosis.ts
@@ -1,3 +1,5 @@
+import { TAnswerType } from "./answer.type";
+
 export interface IDiagnosisPatchData {
   diagnosis_id: number;
 }
@@ -48,13 +50,16 @@ export interface IDiagnosisResult {
 export interface IAnswer {
   answer_id: number;
   answer: string;
+  next_question: IQuestion | null;
 }
 
 export interface IQuestion {
   id: number;
   question: string;
-  answers: IAnswer[];
   is_multiple: boolean;
+  image_url: string | null;
+  answer_type: TAnswerType;
+  answers: IAnswer[] | null;
 }
 
 export interface IDecisiveDate {
@@ -70,7 +75,8 @@ export interface IDecisiveDate {
 }
 
 export interface IDiagnoseResponse {
-  questions: IQuestion;
+  category: string;
+  question: IQuestion[];
 }
 
 export interface IDiagnoseAnswers {

--- a/src/pages/diagnosis/answerButtons/index.tsx
+++ b/src/pages/diagnosis/answerButtons/index.tsx
@@ -47,7 +47,7 @@ const AnswerButtons = ({ question, selectedAnswer, setSelectedAnswer, handleNext
     <Container>
       {/* 답변 유형에 따라 다른 컴포넌트 렌더링할 수 있도록 */}
       <Buttons
-        answers={question.answers}
+        answers={question.answers ?? []}
         question={question}
         selectedAnswer={selectedAnswer}
         handleActive={handleActive}

--- a/src/pages/diagnosis/rangeAnswerButton/index.tsx
+++ b/src/pages/diagnosis/rangeAnswerButton/index.tsx
@@ -13,7 +13,13 @@ interface IRangeAnswer {
 const RangeAnswerButton = ({ answers, selectedAnswer, question, setSelectedAnswer, handleActive }: IRangeAnswer) => {
   const handleRangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     const selectedIdx = Number(e.target.value);
-    setSelectedAnswer([{ answer_id: question.answers[selectedIdx].answer_id, answer: question.answers[selectedIdx].answer }]);
+    setSelectedAnswer([
+      {
+        answer_id: (question.answers ?? [])[selectedIdx].answer_id,
+        answer: (question.answers ?? [])[selectedIdx].answer,
+        next_question: (question.answers ?? [])[selectedIdx].next_question,
+      },
+    ]);
   };
 
   return (


### PR DESCRIPTION
## 🛠 관련 이슈
- [[Refactor] Diagnose Type을 API에 맞게 변경](https://github.com/healthier-devs/healthier-frontend/issues/71)

## 📝 작업 사항
- `IDiagnoseResponse`를 변경된 응답 스키마에 맞게 변경했습니다.

- `IDiagnoseResponse.question.answers`가 `null`이 허용돼서 임시로 nullish 병합 연산자로 `[]`로 바꿨습니다.

  - 요 부분은 백엔드에서 `null` 대신 `[]`로 보내주거나,
 
  - `IDiagnoseResponse.question.answers`가 `null`인 경우와 `null`이 아닌 경우 두 가지 interface로 나누는 방법으로 해결해야 할 것 같습니다.
