### PR TITLE
[Feat] 허리 통증 질문 로직 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  });
+  }, []);
 
   return (
     <Main>

--- a/src/api/diagnose/backpain.ts
+++ b/src/api/diagnose/backpain.ts
@@ -1,0 +1,6 @@
+import { diagnosisFetcher } from "./fetcher";
+import { IDiagnoseResponse } from "src/interfaces/diagnoseApi/diagnosis";
+
+export const BackpainDiagnose = {
+  getQuestions: (): Promise<IDiagnoseResponse> => diagnosisFetcher.get(`/backpain`),
+};

--- a/src/api/diagnose/fetcher.ts
+++ b/src/api/diagnose/fetcher.ts
@@ -1,0 +1,13 @@
+import axios, { AxiosResponse } from "axios";
+
+const instance = axios.create({
+  baseURL: `${process.env.REACT_APP_SERVER_URL}/api/diagnose`,
+  timeout: 15000,
+});
+
+const responseBody = (response: AxiosResponse) => response.data;
+
+export const diagnosisFetcher = {
+  get: <T>(url: string) => instance.get<T>(url).then(responseBody),
+  post: <T>(url: string, body: T) => instance.post<T>(url, body).then(responseBody),
+};

--- a/src/hooks/diagnose/useBackpain.ts
+++ b/src/hooks/diagnose/useBackpain.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { IUseDiagnosis } from "src/interfaces/diagnosisHook";
+import { IQuestion } from "src/interfaces/diagnoseApi/diagnosis";
+import { BackpainDiagnose } from "src/api/diagnose/backpain";
+import { getNextQuestion } from "src/utils/diagnosisHook";
+
+function useBackpain({ curQuestion, setCurQuestion, selectedAnswer, setSelectedAnswer }: IUseDiagnosis) {
+  const questions = useRef<IQuestion[]>([]);
+  const questionHistory = useRef<IQuestion[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const getFirstQuestion = async () => {
+      const { question: backpainQuestions } = await BackpainDiagnose.getQuestions();
+      questions.current = backpainQuestions;
+      setCurQuestion(backpainQuestions[0]);
+    };
+
+    getFirstQuestion();
+  }, [setCurQuestion]);
+
+  const handleBackpainNextLogic = () => {
+    if (questionHistory.current === undefined || questions.current === undefined) {
+      return;
+    }
+
+    questionHistory.current = [...questionHistory.current, curQuestion];
+
+    const nextQuestion = getNextQuestion({
+      selectedAnswer,
+      curQuestion,
+      questions: questions.current,
+    });
+
+    if (nextQuestion) {
+      setCurQuestion(nextQuestion);
+    }
+    setSelectedAnswer([]);
+  };
+
+  const handleBackpainBackLogic = () => {
+    if (questionHistory.current === undefined || questions.current === undefined) {
+      return;
+    }
+
+    if (questionHistory.current.length === 0) {
+      navigate(-1);
+
+      return;
+    }
+
+    const lastIdx = questionHistory.current.length - 1;
+
+    setCurQuestion(questionHistory.current[lastIdx]);
+    questionHistory.current = questionHistory.current.slice(0, lastIdx);
+  };
+
+  return { handleBackpainBackLogic, handleBackpainNextLogic };
+}
+
+export default useBackpain;

--- a/src/hooks/diagnose/useDiagnosis.ts
+++ b/src/hooks/diagnose/useDiagnosis.ts
@@ -6,6 +6,7 @@ import { resetAnswer } from "src/state/answerSlice";
 import { DIAGNOSE_TYPE } from "src/utils/diagnosis";
 import { ANSWER_TYPE } from "src/data/answer_type";
 import useStomache from "./useStomache";
+import useBackpain from "./useBackpain";
 
 function useDiagnosis(state: string) {
   const navigate = useNavigate();
@@ -31,6 +32,15 @@ function useDiagnosis(state: string) {
     setLoading,
   });
 
+  const { handleBackpainBackLogic, handleBackpainNextLogic } = useBackpain({
+    state,
+    curQuestion,
+    setCurQuestion,
+    selectedAnswer,
+    setSelectedAnswer,
+    setLoading,
+  });
+
   useEffect(() => {
     if (!state) navigate("/");
     dispatch(resetAnswer());
@@ -39,12 +49,16 @@ function useDiagnosis(state: string) {
   const handleNext = async () => {
     if (state === DIAGNOSE_TYPE.stomache) {
       handleStomacheNextLogic();
+    } else if (state === DIAGNOSE_TYPE.backpain) {
+      handleBackpainNextLogic();
     }
   };
 
   const handleBack = async () => {
     if (state === DIAGNOSE_TYPE.stomache) {
       handleStomacheBackLogic();
+    } else if (state === DIAGNOSE_TYPE.backpain) {
+      handleBackpainBackLogic();
     }
   };
 

--- a/src/interfaces/diagnosisHook.ts
+++ b/src/interfaces/diagnosisHook.ts
@@ -1,0 +1,11 @@
+import { Dispatch } from "react";
+import { IQuestion, IAnswer } from "./diagnoseApi/diagnosis";
+
+export interface IUseDiagnosis {
+  state: string;
+  curQuestion: IQuestion;
+  setCurQuestion: Dispatch<IQuestion>;
+  selectedAnswer: IAnswer[];
+  setSelectedAnswer: Dispatch<IAnswer[]>;
+  setLoading: Dispatch<boolean>;
+}

--- a/src/pages/diagnosis/answerButtons/index.tsx
+++ b/src/pages/diagnosis/answerButtons/index.tsx
@@ -6,6 +6,9 @@ import { useAppDispatch } from "src/state";
 import { Container, NextButton } from "./index.style";
 import { IAnswer, IQuestion } from "src/interfaces/diagnoseApi/diagnosis";
 import Buttons from "../buttons";
+import NumberButtons from "../number";
+import RangeAnswerButton from "../rangeAnswerButton";
+import { ANSWER_TYPE } from "src/data/answer_type";
 
 interface IAnswerButtonProps {
   question: IQuestion;
@@ -19,7 +22,7 @@ const AnswerButtons = ({ question, selectedAnswer, setSelectedAnswer, handleNext
 
   useEffect(() => {
     selectedAnswer.sort((a, b) => a.answer_id - b.answer_id);
-    if (!question.is_multiple && selectedAnswer.length !== 0) {
+    if (question.answers && !question.is_multiple && selectedAnswer.length !== 0) {
       const timer = setTimeout(() => {
         handleNext();
         clearTimeout(timer);
@@ -30,6 +33,7 @@ const AnswerButtons = ({ question, selectedAnswer, setSelectedAnswer, handleNext
   const handleActive = (id: number): boolean => {
     return selectedAnswer.findIndex((ans) => ans.answer_id === id) !== -1;
   };
+
   const handleMultipleAnswer = () => {
     if (selectedAnswer.length === 0) return;
 
@@ -43,9 +47,24 @@ const AnswerButtons = ({ question, selectedAnswer, setSelectedAnswer, handleNext
     handleNext();
   };
 
+  if (question.answer_type.startsWith("NUMBER")) {
+    return (
+      <NumberButtons question={question} selectedAnswer={selectedAnswer} setSelectedAnswer={setSelectedAnswer} handleNext={handleNext} />
+    );
+  } else if (question.answer_type === ANSWER_TYPE.DRAG_1) {
+    return (
+      <RangeAnswerButton
+        answers={question.answers ?? []}
+        selectedAnswer={selectedAnswer}
+        question={question}
+        handleActive={handleActive}
+        setSelectedAnswer={setSelectedAnswer}
+      />
+    );
+  }
+
   return (
     <Container>
-      {/* 답변 유형에 따라 다른 컴포넌트 렌더링할 수 있도록 */}
       <Buttons
         answers={question.answers ?? []}
         question={question}
@@ -53,7 +72,6 @@ const AnswerButtons = ({ question, selectedAnswer, setSelectedAnswer, handleNext
         handleActive={handleActive}
         setSelectedAnswer={setSelectedAnswer}
       />
-
       {question.is_multiple && (
         <NextButton onClick={handleMultipleAnswer}>
           <RoundButton

--- a/src/pages/diagnosis/number/durationButton/index.style.tsx
+++ b/src/pages/diagnosis/number/durationButton/index.style.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const DurationButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const DurationInput = styled.input``;
+
+export const DurationSelect = styled.select``;
+
+export const DurationText = styled.div`
+  color: #fff;
+`;

--- a/src/pages/diagnosis/number/durationButton/index.tsx
+++ b/src/pages/diagnosis/number/durationButton/index.tsx
@@ -1,0 +1,78 @@
+import { Dispatch, useEffect, useState } from "react";
+import { IQuestion, IAnswer } from "src/interfaces/diagnoseApi/diagnosis";
+import { DurationButtonContainer, DurationInput, DurationSelect, DurationText } from "./index.style";
+import { validateNumber } from "src/utils/inputValidator";
+
+const SELECT_TYPES = [
+  {
+    value: "day",
+    text: "일",
+  },
+  {
+    value: "month",
+    text: "월",
+  },
+  {
+    value: "year",
+    text: "년",
+  },
+] as const;
+
+interface IDuration {
+  number: number;
+  type: string;
+}
+
+interface IDurationButtonProps {
+  question: IQuestion;
+  selectedAnswer: IAnswer[];
+  setSelectedAnswer: Dispatch<IAnswer[]>;
+}
+
+function DurationButton({ setSelectedAnswer }: IDurationButtonProps) {
+  const [duration, setDuration] = useState<IDuration>({
+    number: 0,
+    type: "day",
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // TODO: 최대 숫자 설정 필요
+    const number = validateNumber(e.target.value);
+    setDuration({ ...duration, number: number });
+  };
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setDuration({ ...duration, type: e.target.value });
+  };
+
+  useEffect(() => {
+    if (duration.number === 0) {
+      setSelectedAnswer([]);
+      return;
+    }
+
+    setSelectedAnswer([
+      {
+        answer_id: 0,
+        answer: duration.number + duration.type,
+        next_question: null,
+      },
+    ]);
+  }, [duration, setSelectedAnswer]);
+
+  return (
+    <DurationButtonContainer>
+      <DurationInput type="number" value={duration.number || ""} onChange={handleInputChange} />
+      <DurationSelect value={duration.type} onChange={handleSelectChange}>
+        {SELECT_TYPES.map(({ value, text }) => (
+          <option key={value} value={value}>
+            {text}
+          </option>
+        ))}
+      </DurationSelect>
+      <DurationText>전</DurationText>
+    </DurationButtonContainer>
+  );
+}
+
+export default DurationButton;

--- a/src/pages/diagnosis/number/index.tsx
+++ b/src/pages/diagnosis/number/index.tsx
@@ -1,0 +1,43 @@
+import { Dispatch } from "react";
+import { IQuestion, IAnswer } from "src/interfaces/diagnoseApi/diagnosis";
+import RoundButton from "src/components/roundButton";
+import theme from "src/lib/theme";
+import { Container } from "../index.style";
+import { NextButton } from "../answerButtons/index.style";
+import NumberAnswerButton from "./numberAnswerButton";
+
+interface INumberButtonProps {
+  question: IQuestion;
+  selectedAnswer: IAnswer[];
+  setSelectedAnswer: Dispatch<IAnswer[]>;
+  handleNext: () => void;
+}
+
+function NumberButtons({ question, selectedAnswer, setSelectedAnswer, handleNext }: INumberButtonProps) {
+  const handleNextButtonClick = () => {
+    if (selectedAnswer.length === 0) {
+      return;
+    }
+
+    // TODO: answer state 저장
+
+    handleNext();
+  };
+
+  return (
+    <Container>
+      <NumberAnswerButton question={question} selectedAnswer={selectedAnswer} setSelectedAnswer={setSelectedAnswer} />
+      <NextButton onClick={handleNextButtonClick}>
+        <RoundButton
+          outline="none"
+          backgroundColor={selectedAnswer.length === 0 ? theme.color.grey_650 : theme.color.blue}
+          color={selectedAnswer.length === 0 ? theme.color.grey_400 : theme.color.grey_100}
+        >
+          다음 단계
+        </RoundButton>
+      </NextButton>
+    </Container>
+  );
+}
+
+export default NumberButtons;

--- a/src/pages/diagnosis/number/numberAnswerButton/index.tsx
+++ b/src/pages/diagnosis/number/numberAnswerButton/index.tsx
@@ -1,0 +1,23 @@
+import { Dispatch } from "react";
+import { IQuestion, IAnswer } from "src/interfaces/diagnoseApi/diagnosis";
+import { ANSWER_TYPE } from "src/data/answer_type";
+import DurationButton from "../durationButton";
+import PreviousTimeButton from "../previousTimeButton";
+
+interface INumberAnswerButtonProps {
+  question: IQuestion;
+  selectedAnswer: IAnswer[];
+  setSelectedAnswer: Dispatch<IAnswer[]>;
+}
+
+function NumberAnswerButton({ question, selectedAnswer, setSelectedAnswer }: INumberAnswerButtonProps) {
+  if (question.answer_type === ANSWER_TYPE.NUMBER_1) {
+    return <DurationButton question={question} selectedAnswer={selectedAnswer} setSelectedAnswer={setSelectedAnswer} />;
+  } else if (question.answer_type === ANSWER_TYPE.NUMBER_2) {
+    return <PreviousTimeButton question={question} selectedAnswer={selectedAnswer} setSelectedAnswer={setSelectedAnswer} />;
+  }
+
+  return <div>구현 필요</div>;
+}
+
+export default NumberAnswerButton;

--- a/src/pages/diagnosis/number/previousTimeButton/index.style.tsx
+++ b/src/pages/diagnosis/number/previousTimeButton/index.style.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const PreviousTimeButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const PreviousTimeInput = styled.input``;
+
+export const PreviousTimeSelect = styled.select``;
+
+export const PreviousTimeText = styled.div`
+  color: #fff;
+`;

--- a/src/pages/diagnosis/number/previousTimeButton/index.tsx
+++ b/src/pages/diagnosis/number/previousTimeButton/index.tsx
@@ -1,0 +1,68 @@
+import { Dispatch, useState, useEffect } from "react";
+import { PreviousTimeButtonContainer, PreviousTimeInput, PreviousTimeSelect, PreviousTimeText } from "./index.style";
+import { validateNumber } from "src/utils/inputValidator";
+import { IQuestion, IAnswer } from "src/interfaces/diagnoseApi/diagnosis";
+
+const SELECT_TYPES = [
+  { value: "hour", text: "시간" },
+  { value: "day", text: "일" },
+] as const;
+
+interface IPreviousTime {
+  number: number;
+  type: string;
+}
+
+interface IPreviousTimeButtonProps {
+  question: IQuestion;
+  selectedAnswer: IAnswer[];
+  setSelectedAnswer: Dispatch<IAnswer[]>;
+}
+
+function PreviousTimeButton({ setSelectedAnswer }: IPreviousTimeButtonProps) {
+  const [previousTime, setPreviousTime] = useState<IPreviousTime>({
+    number: 0,
+    type: "hour",
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // TODO: 최대 숫자 설정 필요
+    const number = validateNumber(e.target.value);
+    setPreviousTime({ ...previousTime, number: number });
+  };
+
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setPreviousTime({ ...previousTime, type: e.target.value });
+  };
+
+  useEffect(() => {
+    if (previousTime.number === 0) {
+      setSelectedAnswer([]);
+      return;
+    }
+
+    setSelectedAnswer([
+      {
+        answer_id: 0,
+        answer: previousTime.number + previousTime.type,
+        next_question: null,
+      },
+    ]);
+  }, [previousTime, setSelectedAnswer]);
+
+  return (
+    <PreviousTimeButtonContainer>
+      <PreviousTimeInput value={previousTime.number || ""} onChange={handleInputChange} />
+      <PreviousTimeSelect value={previousTime.type} onChange={handleSelectChange}>
+        {SELECT_TYPES.map(({ value, text }) => (
+          <option key={value} value={value}>
+            {text}
+          </option>
+        ))}
+      </PreviousTimeSelect>
+      <PreviousTimeText>전</PreviousTimeText>
+    </PreviousTimeButtonContainer>
+  );
+}
+
+export default PreviousTimeButton;

--- a/src/pages/diagnosis/rangeAnswerButton/index.tsx
+++ b/src/pages/diagnosis/rangeAnswerButton/index.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, Dispatch } from "react";
 import { IAnswer, IQuestion } from "src/interfaces/diagnoseApi/diagnosis";
+import { Container } from "../answerButtons/index.style";
 import { RangeAnswerContainer, RangeBackground, RangeAnswer, RangeContainer, RangeInput, RangeNumber } from "./index.style";
 
 interface IRangeAnswer {
@@ -23,32 +24,34 @@ const RangeAnswerButton = ({ answers, selectedAnswer, question, setSelectedAnswe
   };
 
   return (
-    <RangeAnswerContainer>
-      <div className="range-answers">
-        {answers.length !== 0 &&
-          answers.map((ans, idx) => (
-            <RangeAnswer key={idx} idx={idx} selected={handleActive(5 - ans.answer_id)}>
-              <div className="answer-text">{ans.answer}</div>
-              <div className="range-dots" />
-            </RangeAnswer>
+    <Container>
+      <RangeAnswerContainer>
+        <div className="range-answers">
+          {answers.length !== 0 &&
+            answers.map((ans, idx) => (
+              <RangeAnswer key={idx} idx={idx} selected={handleActive(5 - ans.answer_id)}>
+                <div className="answer-text">{ans.answer}</div>
+                <div className="range-dots" />
+              </RangeAnswer>
+            ))}
+        </div>
+        <RangeContainer>
+          <RangeBackground />
+          <RangeInput
+            type="range"
+            min={0}
+            max={5}
+            value={selectedAnswer.length >= 1 ? selectedAnswer[0].answer_id : answers[3].answer_id}
+            onChange={handleRangeInput}
+          />
+        </RangeContainer>
+        <div className="range-numbers">
+          {[100, 50, 0].map((num) => (
+            <RangeNumber key={num}>{num}</RangeNumber>
           ))}
-      </div>
-      <RangeContainer>
-        <RangeBackground />
-        <RangeInput
-          type="range"
-          min={0}
-          max={5}
-          value={selectedAnswer.length >= 1 ? selectedAnswer[0].answer_id : answers[3].answer_id}
-          onChange={handleRangeInput}
-        />
-      </RangeContainer>
-      <div className="range-numbers">
-        {[100, 50, 0].map((num) => (
-          <RangeNumber key={num}>{num}</RangeNumber>
-        ))}
-      </div>
-    </RangeAnswerContainer>
+        </div>
+      </RangeAnswerContainer>
+    </Container>
   );
 };
 

--- a/src/pages/symptomType/index.tsx
+++ b/src/pages/symptomType/index.tsx
@@ -8,7 +8,10 @@ import { DIAGNOSE_TYPE } from "src/utils/diagnosis";
 import RoundButton from "src/components/roundButton";
 import theme from "src/lib/theme";
 
-const symptomTypes = [{ state: DIAGNOSE_TYPE.stomache, text: "급성복통" }];
+const symptomTypes = [
+  { state: DIAGNOSE_TYPE.stomache, text: "급성복통" },
+  { state: DIAGNOSE_TYPE.backpain, text: "허리통증" },
+];
 
 const SymptomTypePage = () => {
   const navigate = useNavigate();

--- a/src/utils/diagnosis.ts
+++ b/src/utils/diagnosis.ts
@@ -2,6 +2,7 @@ import { BodyPart } from "src/interfaces/symptomPage";
 
 export const DIAGNOSE_TYPE = {
   stomache: "급성복통",
+  backpain: "허리통증",
 };
 
 export const PAIN_AREA_MAP = {

--- a/src/utils/diagnosisHook.ts
+++ b/src/utils/diagnosisHook.ts
@@ -1,0 +1,17 @@
+import { IAnswer, IQuestion } from "src/interfaces/diagnoseApi/diagnosis";
+
+interface IGetNextQuestionParams {
+  selectedAnswer: IAnswer[];
+  curQuestion: IQuestion;
+  questions: IQuestion[];
+}
+
+export const getNextQuestion = ({ selectedAnswer, curQuestion, questions }: IGetNextQuestionParams): IQuestion | null => {
+  const nextQuestionIdx = questions.findIndex((question) => question.id > curQuestion.id);
+
+  if (nextQuestionIdx === questions.length) {
+    return null;
+  }
+
+  return selectedAnswer[0]?.next_question ?? questions[nextQuestionIdx];
+};

--- a/src/utils/inputValidator.ts
+++ b/src/utils/inputValidator.ts
@@ -1,0 +1,9 @@
+export const validateNumber = (input: string) => {
+  const parsedNumber = parseInt(input);
+
+  if (isNaN(parsedNumber) || parsedNumber <= 0) {
+    return 0;
+  }
+
+  return parsedNumber;
+};


### PR DESCRIPTION
## 🛠 관련 이슈
- close #69 

## 📝 작업 사항
- App.tsx의 `useEffect`에 의존성 추가
  - App 컴포넌트가 재렌더링 될 일이 없지만, 의존성을 명확하게 하기 위해 `[]` 추가

- 진단 api의 공통 axios instance 생성

- 응답 타입 `NUMBER_1`, `NUMBER_2` 컴포넌트 생성
  - 디자인 나오면 수정될 여지가 다분합니다...

- 응답 타입에 따른 응답 버튼 렌더링

- 허리 통증 커스텀훅(질문만) 구현