### PR TITLE
[Refactor] 결과페이지 UI 수정

### DIFF
--- a/src/components/treatmentTag/index.stories.tsx
+++ b/src/components/treatmentTag/index.stories.tsx
@@ -1,0 +1,30 @@
+import TreatmentTag from ".";
+import { ITreatmentTag } from "src/interfaces/component";
+import { Meta, Story } from "@storybook/react";
+
+export default {
+  component: TreatmentTag,
+  title: "TreatmentTag",
+  argTypes: {
+    type: {
+      description: "태그 유형",
+      options: ["therapy", "inspection"],
+      control: {
+        type: "select",
+        labels: ["therapy", "inspection"],
+      },
+    },
+  },
+} as Meta;
+
+const Template: Story<ITreatmentTag> = (args) => <TreatmentTag {...args} />;
+
+export const Therapy = Template.bind({});
+Therapy.args = {
+  type: "therapy",
+};
+
+export const Inspection = Template.bind({});
+Inspection.args = {
+  type: "inspection",
+};

--- a/src/components/treatmentTag/index.style.tsx
+++ b/src/components/treatmentTag/index.style.tsx
@@ -1,0 +1,24 @@
+import { ITreatmentType } from "src/interfaces/component";
+import styled, { css } from "styled-components";
+
+export const Container = styled.section<{ type: ITreatmentType }>`
+  display: inline-block;
+  padding: 0.4rem 0.8rem;
+  border-radius: 0.8rem;
+
+  font-weight: 400;
+  font-size: 1.2rem;
+  line-height: 1.4rem;
+  letter-spacing: -0.03rem;
+
+  ${({ type, theme }) =>
+    type === "therapy"
+      ? css`
+          color: ${theme.color.blue_100};
+          background: rgba(157, 167, 242, 0.3);
+        `
+      : css`
+          color: ${theme.color.green_300};
+          background: rgba(230, 250, 175, 0.25);
+        `}
+`;

--- a/src/components/treatmentTag/index.style.tsx
+++ b/src/components/treatmentTag/index.style.tsx
@@ -3,6 +3,7 @@ import styled, { css } from "styled-components";
 
 export const Container = styled.section<{ type: ITreatmentType }>`
   display: inline-block;
+  height: 100%;
   padding: 0.4rem 0.8rem;
   border-radius: 0.8rem;
 

--- a/src/components/treatmentTag/index.tsx
+++ b/src/components/treatmentTag/index.tsx
@@ -1,0 +1,8 @@
+import { Container } from "./index.style";
+import { ITreatmentTag } from "src/interfaces/component";
+
+const TreatmentTag = ({ type }: ITreatmentTag) => {
+  return <Container type={type}>{type === "therapy" ? "치료" : "검사"}</Container>;
+};
+
+export default TreatmentTag;

--- a/src/hooks/useDiagnosisResult.ts
+++ b/src/hooks/useDiagnosisResult.ts
@@ -17,10 +17,11 @@ function useDiagnosisResult(state: IDiagnosticResult) {
     title: "",
     definition: [],
     tag_flag: 0,
+    cause: null,
     cause_detail: [],
   });
   const [lifeData, setLifeData] = useState([] as ILifeProps[]);
-  const [medicineData, setMedicineData] = useState<IMedicine[] | undefined>();
+  const [medicineData, setMedicineData] = useState<IMedicine[] | null>();
   const [treatData, setTreatData] = useState<ITreatPageProps[] | undefined>();
 
   const [isSaved, setIsSaved] = useState(false);

--- a/src/interfaces/component.ts
+++ b/src/interfaces/component.ts
@@ -25,6 +25,11 @@ export interface ITag {
   selected: boolean;
 }
 
+export type ITreatmentType = "therapy" | "inspection";
+export interface ITreatmentTag {
+  type: ITreatmentType;
+}
+
 export interface IDropdown {
   title: string;
   isSelected: boolean;

--- a/src/interfaces/diagnosticResult.ts
+++ b/src/interfaces/diagnosticResult.ts
@@ -1,4 +1,4 @@
-import { IDiagnosisList } from "./component";
+import { IDiagnosisList, ITreatmentType } from "./component";
 
 export interface IDiagnosticResult {
   type: string;
@@ -28,7 +28,7 @@ export interface IDiagnosticResult {
         }[]
       | null;
     treatment_flag: number;
-    treatments?: { title: string; detail: string }[];
+    treatments?: { title: string; detail: string; type: ITreatmentType }[];
   };
 }
 

--- a/src/interfaces/diagnosticResult.ts
+++ b/src/interfaces/diagnosticResult.ts
@@ -12,19 +12,21 @@ export interface IDiagnosticResult {
     explanation: { title: string; details: string[] };
     cause: {
       tag_flag: number;
-      tags?: { cause: string; details: string[] }[];
+      tags: { cause: string; details: string[] }[] | null;
       detail: string[];
     };
     solutions: { title: string; detail: string; emoji: string }[];
     medicine_flag: number;
-    medicines?: {
-      image: string;
-      name: string;
-      efficacy: string;
-      dosage_and_uses?: { name: string; emoji: string }[];
-      caution: { h1: string; h2: string; is_colored: string[] };
-      sideeffects: { name: string; emoji: string }[];
-    }[];
+    medicines:
+      | {
+          image: string;
+          name: string;
+          efficacy: string;
+          dosage_and_uses?: { name: string; emoji: string }[];
+          caution: { h1: string; h2: string; is_colored: string[] };
+          sideeffects: { name: string; emoji: string }[];
+        }[]
+      | null;
     treatment_flag: number;
     treatments?: { title: string; detail: string }[];
   };

--- a/src/interfaces/resultPage.ts
+++ b/src/interfaces/resultPage.ts
@@ -24,7 +24,7 @@ export interface IDefinePageProps {
   title: string;
   definition: string[];
   tag_flag: number;
-  cause?: { cause: string; details: string[] }[];
+  cause: { cause: string; details: string[] }[] | null;
   cause_detail: string[];
 }
 

--- a/src/interfaces/resultPage.ts
+++ b/src/interfaces/resultPage.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from "react";
+import { ITreatmentType } from "./component";
 
 export interface IBottomNumber {
   curIndex: number;
@@ -79,9 +80,11 @@ export interface IMedicineTag {
 export interface ITreatPageProps {
   title: string;
   detail: string;
+  type: ITreatmentType;
 }
 
 export interface ITreatBoxProps {
   title: string;
   description: string;
+  type: ITreatmentType;
 }

--- a/src/pages/result/coverPage/index.style.tsx
+++ b/src/pages/result/coverPage/index.style.tsx
@@ -21,7 +21,9 @@ export const Contents = styled.section`
   flex-direction: column;
   align-items: center;
 
-  margin: 4.5rem 3.2rem 4rem 3.2rem;
+  width: 31rem;
+
+  margin: 3.2rem 0 6rem 0;
 `;
 
 export const SeverityText = styled(Body_2)`

--- a/src/pages/result/coverPage/index.style.tsx
+++ b/src/pages/result/coverPage/index.style.tsx
@@ -11,6 +11,14 @@ export const Container = styled.section`
   height: calc(var(--vw, 1vw) * 100 + 27.4rem);
 `;
 
+export const TagContainer = styled.section`
+  margin-top: 2.8rem;
+
+  section + section {
+    margin-left: 0.8rem;
+  }
+`;
+
 export const CoverImage = styled.img`
   width: calc(var(--vw, 1vw) * 100);
   height: calc(var(--vw, 1vw) * 100);

--- a/src/pages/result/coverPage/index.style.tsx
+++ b/src/pages/result/coverPage/index.style.tsx
@@ -6,6 +6,7 @@ export const Container = styled.section`
 
   display: flex;
   flex-direction: column;
+  align-items: center;
 
   height: calc(var(--vw, 1vw) * 100 + 27.4rem);
 `;
@@ -23,7 +24,7 @@ export const Contents = styled.section`
 
   width: 31rem;
 
-  margin: 3.2rem 0 6rem 0;
+  margin: 3.2rem 0 6.6rem 0;
 `;
 
 export const SeverityText = styled(Body_2)`

--- a/src/pages/result/coverPage/index.style.tsx
+++ b/src/pages/result/coverPage/index.style.tsx
@@ -7,8 +7,6 @@ export const Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  height: calc(var(--vw, 1vw) * 100 + 27.4rem);
 `;
 
 export const TagContainer = styled.section`

--- a/src/pages/result/coverPage/index.tsx
+++ b/src/pages/result/coverPage/index.tsx
@@ -1,8 +1,11 @@
+import Tag from "src/components/tag";
 import { ICoverPageProps } from "src/interfaces/resultPage";
 import SeverityBar from "../severityBar";
-import { Container, CoverImage, Contents, SeverityText, Title, Description } from "./index.style";
+import { Container, CoverImage, Contents, SeverityText, Title, Description, TagContainer } from "./index.style";
 
 const CoverPage = ({ coverData: { illustration, highlight, title, description, severity } }: { coverData: ICoverPageProps }) => {
+  const tags = ["신경과", "정신건강의학과"];
+
   return (
     <Container>
       <CoverImage loading="eager" alt="cover" src={illustration} />
@@ -13,6 +16,13 @@ const CoverPage = ({ coverData: { illustration, highlight, title, description, s
         {description.map((des, idx) => (
           <Description key={idx}>{des}</Description>
         ))}
+        <TagContainer>
+          {tags.map((tag, idx) => (
+            <Tag key={idx} selected={false}>
+              {tag}
+            </Tag>
+          ))}
+        </TagContainer>
       </Contents>
       <SeverityBar severity={severity} />
     </Container>

--- a/src/pages/result/definitionPage/index.style.tsx
+++ b/src/pages/result/definitionPage/index.style.tsx
@@ -17,7 +17,7 @@ export const DescriptionBox = styled.section<{ top: number; bottom: number }>`
 `;
 
 export const SymptomBox = styled.section`
-  margin-bottom: 6rem;
+  margin-bottom: 7.2rem;
 `;
 
 export const SymptomText = styled(Body_1)`

--- a/src/pages/result/definitionPage/index.style.tsx
+++ b/src/pages/result/definitionPage/index.style.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Body_1 } from "src/lib/fontStyle";
 
 export const Container = styled.section`
   padding-top: 5.6rem;
@@ -13,4 +14,21 @@ export const Container = styled.section`
 export const DescriptionBox = styled.section<{ top: number; bottom: number }>`
   margin-top: ${({ top }) => top}rem;
   margin-bottom: ${({ bottom }) => bottom}rem;
+`;
+
+export const SymptomBox = styled.section`
+  margin-bottom: 6rem;
+`;
+
+export const SymptomText = styled(Body_1)`
+  font-weight: 300;
+  color: ${({ theme }) => theme.color.grey_300};
+`;
+
+export const SymptomTags = styled.section`
+  margin-top: 1.2rem;
+
+  section {
+    margin-right: 0.8rem;
+  }
 `;

--- a/src/pages/result/definitionPage/index.tsx
+++ b/src/pages/result/definitionPage/index.tsx
@@ -2,18 +2,31 @@ import Title from "src/components/title";
 import Description from "../description";
 import CauseBox from "../causeBox";
 import { IDefinePageProps } from "src/interfaces/resultPage";
-import { Container, DescriptionBox } from "./index.style";
+import { Container, DescriptionBox, SymptomBox, SymptomTags, SymptomText } from "./index.style";
+import Tag from "src/components/tag";
 
 const DefinitionPage = ({ defineData: { title, definition, tag_flag, cause, cause_detail } }: { defineData: IDefinePageProps }) => {
+  const tags = ["피로감", "졸림", "불면증"];
+
   return (
     <Container>
       <section className="contents">
         <Title text={title} />
-        <DescriptionBox top={2} bottom={8}>
+        <DescriptionBox top={2} bottom={3}>
           {definition.map((text, idx) => (
             <section key={idx}>{text ? <Description text={text} /> : <br />}</section>
           ))}
         </DescriptionBox>
+        <SymptomBox>
+          <SymptomText>다음과 같은 증상이 나타날 수 있어요</SymptomText>
+          <SymptomTags>
+            {tags.map((tag, idx) => (
+              <Tag key={idx} selected={false}>
+                {tag}
+              </Tag>
+            ))}
+          </SymptomTags>
+        </SymptomBox>
         <Title text="원인이 무엇인가요?" />
         {cause?.length === 2 && <CauseBox cause_1={cause[0]} cause_2={cause[1]} />}
         <DescriptionBox top={tag_flag === 1 ? 1.6 : 2} bottom={0}>

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -26,8 +26,8 @@ const state = {
       "https://healthier.s3.ap-northeast-2.amazonaws.com/%EC%A7%84%EB%8B%A8%EA%B2%B0%EA%B3%BC/sleepdisorder/62e126cb1549f1a6fe9f58b1.jpg",
     h1: "진통제를 많이 먹어 두통이 생기는 당신은",
     title: "약물 과용 두통",
-    h2: ["과다 복용한 두통 약물을 중단하고',", "두통 유발인자를 피할 수 있도록 생활습관을 개선해보세요."],
-    severity: 2,
+    h2: ["과다 복용한 두통 약물을 중단하고,", "두통 유발인자를 피할 수 있도록 생활습관을 개선해보세요."],
+    severity: 0,
     explanation: {
       title: "약물 과용 두통이란?",
       details: ["편두통으로 진통제를 과다하게 복용하면 몸에서", "통증을 억제하는 기능이 망가져 발생할 수 있어요."],

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -18,8 +18,74 @@ import Loading from "src/components/loading";
 import imageUrl from "src/data/image_url";
 import useDiagnosisResult from "src/hooks/useDiagnosisResult";
 
+const state = {
+  type: "1",
+  diagnostic_result: {
+    id: 1025,
+    illustration:
+      "https://healthier.s3.ap-northeast-2.amazonaws.com/%EC%A7%84%EB%8B%A8%EA%B2%B0%EA%B3%BC/sleepdisorder/62e126cb1549f1a6fe9f58b1.jpg",
+    h1: "진통제를 많이 먹어 두통이 생기는 당신은",
+    title: "약물 과용 두통",
+    h2: ["과다 복용한 두통 약물을 중단하고',", "두통 유발인자를 피할 수 있도록 생활습관을 개선해보세요."],
+    severity: 2,
+    explanation: {
+      title: "약물 과용 두통이란?",
+      details: ["편두통으로 진통제를 과다하게 복용하면 몸에서", "통증을 억제하는 기능이 망가져 발생할 수 있어요."],
+    },
+    cause: {
+      tag_flag: 0,
+      tags: null,
+      detail: [
+        "진통제를 먹으면 두통과 관련된 신경이 흥분돼요.",
+        "장기간 먹으면 신경계가 과하게 흥분하게 되고",
+        "오히려 통증이 심해질 수 있어요.",
+        "\n",
+        "여러 성분을 섞은 복합진통제를 한 달에 10일 이상, 아스피린·타이레놀 등 한 가지 성분의 단순진통제를 한 달에 15일 이상 복용하면 약물과용두통이 발생할 수 있어요.",
+      ],
+    },
+    solutions: [
+      {
+        title: "두통 유발 음식 피하기",
+        detail:
+          "맥주, 레드와인, 숙성치즈와 초콜릿에 들어있는 효소는 두통을 유발해요. MSG와 같은 인공감미료나 감귤, 바나나, 아보카도와 같은 과일에도 두통 유발성분이 들어있어요.",
+        emoji: "https://drive.google.com/uc?export=view&id=1Ou_GTV8IgfWIlpaN7HzM_JeodgaNyYlE",
+      },
+      {
+        title: "요가나 이완요법 하기",
+        detail: "명상, 스트레칭을 통해 스트레스를 조절하고 긴장된 근육을 이완시키면 편두통의 강도와 빈도를 줄이는데 도움이 돼요.",
+        emoji: "https://drive.google.com/uc?export=view&id=1T97erNMdD-ubjVh19AO20UULiYgXOkhk",
+      },
+      {
+        title: "충분히 휴식하기",
+        detail: "조용하고 어두운 방에서 휴식을 취해보아요. 목 뒤쪽에 얼음주머니를 올려놓거나 두피를 마사지하면 증상이 완화돼요.",
+        emoji: "https://drive.google.com/uc?export=view&id=1ccq7SM1iGa0MA9wS_KIXL6U4ez5veOgd",
+      },
+      {
+        title: " 편두통 일지 기록하기",
+        detail: "두통의 시작일과 지속 기간을 기록해요. 이를 통해 주요 유발 요인이 무엇인지 파악하고 그것을 피하려 노력해보아요.",
+        emoji: "https://drive.google.com/uc?export=view&id=1y85S0-ZSyMumklXC1Cd-9R7U-B5AOlhV",
+      },
+    ],
+    medicine_flag: 0,
+    medicines: null,
+    treatment_flag: 1,
+    treatments: [
+      {
+        title: "구제 약물 처방",
+        detail: "과다 복용한 약물을 중단한 후 발생하는 두통을 치료하는 데 사용되는 구제약물을 처방받을 수 있어요.",
+      },
+      {
+        title: "인지행동치료",
+        detail: "이완 훈련, 최면 및 스트레스 관리를 통해 환자가 건강한 생활습관으로 두통을 조절하거나 완화시킬 수 있는 방법을 배워요.",
+      },
+    ],
+    banner_illustration: "https://healthier.s3.ap-northeast-2.amazonaws.com/banner/headache/62e126cb1549f1a6fe9f58b1.png",
+  },
+};
+
 const ResultPage = () => {
-  const { state } = useLocation() as { state: IDiagnosticResult };
+  //const { state } = useLocation() as { state: IDiagnosticResult };
+
   const { isOpenModal, modalRef, openModal, closeModal } = useModal();
 
   const [curIndex, setCurIndex] = useState(1);

--- a/src/pages/result/index.tsx
+++ b/src/pages/result/index.tsx
@@ -17,6 +17,7 @@ import useModal from "src/hooks/useModal";
 import Loading from "src/components/loading";
 import imageUrl from "src/data/image_url";
 import useDiagnosisResult from "src/hooks/useDiagnosisResult";
+import { ITreatmentType } from "../../interfaces/component";
 
 const state = {
   type: "1",
@@ -73,10 +74,12 @@ const state = {
       {
         title: "구제 약물 처방",
         detail: "과다 복용한 약물을 중단한 후 발생하는 두통을 치료하는 데 사용되는 구제약물을 처방받을 수 있어요.",
+        type: "therapy" as ITreatmentType,
       },
       {
         title: "인지행동치료",
         detail: "이완 훈련, 최면 및 스트레스 관리를 통해 환자가 건강한 생활습관으로 두통을 조절하거나 완화시킬 수 있는 방법을 배워요.",
+        type: "inspection" as ITreatmentType,
       },
     ],
     banner_illustration: "https://healthier.s3.ap-northeast-2.amazonaws.com/banner/headache/62e126cb1549f1a6fe9f58b1.png",

--- a/src/pages/result/severityBar/index.style.tsx
+++ b/src/pages/result/severityBar/index.style.tsx
@@ -23,15 +23,7 @@ export const Text = styled.section<{ type: number; severity: number }>`
   font-size: 1.4rem;
 
   color: ${({ theme, type, severity }) =>
-    type !== severity
-      ? theme.color.grey_400
-      : type === 3
-      ? theme.color.red
-      : type === 2
-      ? "#8A5FD0"
-      : type === 1
-      ? theme.color.blue
-      : theme.color.grey_400};
+    type !== severity ? theme.color.grey_400 : type === 2 ? theme.color.red : type === 1 ? "#8A5FD0" : theme.color.blue};
   font-weight: ${({ type, severity }) => type === severity && 300};
 `;
 

--- a/src/pages/result/severityBar/index.style.tsx
+++ b/src/pages/result/severityBar/index.style.tsx
@@ -41,9 +41,9 @@ export const SeverityBackground = styled.section<{ severity: number }>`
     border-radius: 10rem;
     background: ${({ severity }) =>
       severity === 100
-        ? "linear-gradient(270deg, #E06122 0%, #5464F2 48.96%, #3F444F 100%);"
-        : severity === 65
-        ? "linear-gradient(270deg, #8A5FD0 0%, #4D5ABF 45.08%, #3F444F 100%);"
-        : "linear-gradient(270deg, #4A56A5 0%, #3F444F 100%);"};
+        ? "linear-gradient(270deg, #DF6225 0%, #8A5FD0 52.6%, #4D5ABF 100%);"
+        : severity === 48
+        ? "linear-gradient(270deg, #8A5FD0 0%, #4D5ABF 100%);"
+        : " #4D5ABF;"};
   }
 `;

--- a/src/pages/result/severityBar/index.style.tsx
+++ b/src/pages/result/severityBar/index.style.tsx
@@ -10,31 +10,28 @@ export const Container = styled.section`
   .text-box {
     display: flex;
     justify-content: space-between;
-    width: calc(var(--vw, 1vw) * 100 - 8.6rem);
+    width: calc(var(--vw, 1vw) * 100 - 6.8rem);
 
     font-weight: 100;
     letter-spacing: -0.05rem;
-
-    margin-left: 4.3rem;
   }
 `;
 
 export const Text = styled.section<{ type: number; severity: number }>`
   font-size: 1.4rem;
-
   color: ${({ theme, type, severity }) =>
     type !== severity ? theme.color.grey_400 : type === 2 ? theme.color.red : type === 1 ? "#8A5FD0" : theme.color.blue};
   font-weight: ${({ type, severity }) => type === severity && 300};
+  text-align: center;
 `;
 
 export const SeverityBackground = styled.section<{ severity: number }>`
   margin-top: 1rem;
-  margin-left: 4.3rem;
 
   background: rgba(84, 100, 242, 0.33);
   border-radius: 10rem;
 
-  width: calc(var(--vw, 1vw) * 100 - 8.6rem);
+  width: calc(var(--vw, 1vw) * 100 - 6.8rem);
   height: 0.5rem;
 
   .highlight {

--- a/src/pages/result/severityBar/index.tsx
+++ b/src/pages/result/severityBar/index.tsx
@@ -5,7 +5,7 @@ const setBackgroundPercent = (severity: number): number => {
     case 0:
       return 5;
     case 1:
-      return 55;
+      return 48;
     default:
       return 100;
   }

--- a/src/pages/result/severityBar/index.tsx
+++ b/src/pages/result/severityBar/index.tsx
@@ -5,9 +5,7 @@ const setBackgroundPercent = (severity: number): number => {
     case 0:
       return 5;
     case 1:
-      return 35;
-    case 2:
-      return 65;
+      return 55;
     default:
       return 100;
   }
@@ -18,16 +16,18 @@ const SeverityBar = ({ severity }: { severity: number }) => {
     <Container>
       <section className="text-box">
         <Text type={0} severity={severity}>
-          정상
+          관리가
+          <br />
+          필요해요
         </Text>
         <Text type={1} severity={severity}>
-          경미
+          병원에 가는걸
+          <br />
+          추천해요
         </Text>
         <Text type={2} severity={severity}>
-          주의
-        </Text>
-        <Text type={3} severity={severity}>
-          심각
+          병원에
+          <br />꼭 가야해요
         </Text>
       </section>
       <SeverityBackground severity={setBackgroundPercent(severity)}>

--- a/src/pages/result/treatmentBox/index.style.tsx
+++ b/src/pages/result/treatmentBox/index.style.tsx
@@ -8,6 +8,8 @@ export const Container = styled.section`
 
   padding: 1.8rem 2rem;
 
+  cursor: pointer;
+
   & + & {
     margin-top: 1rem;
   }
@@ -36,6 +38,5 @@ export const Title = styled(Heading_5)`
 `;
 
 export const DropdownIcon = styled.img<{ toggle: boolean }>`
-  cursor: pointer;
   transform: ${({ toggle }) => (toggle ? "rotate(180deg)" : "rotate(0)")};
 `;

--- a/src/pages/result/treatmentBox/index.style.tsx
+++ b/src/pages/result/treatmentBox/index.style.tsx
@@ -1,19 +1,41 @@
 import styled from "styled-components";
 import { Heading_5 } from "src/lib/fontStyle";
+import { Text } from "../description/index.style";
 
 export const Container = styled.section`
   background-color: ${({ theme }) => theme.color.grey_800};
   border-radius: 0.8rem;
 
-  padding: 2rem 2.4rem;
+  padding: 1.8rem 2rem;
 
   & + & {
     margin-top: 1rem;
+  }
+
+  ${Text} {
+    margin-top: 0.8rem;
+  }
+`;
+
+export const TitleContainer = styled.section`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const TitleBox = styled.section`
+  display: flex;
+
+  section {
+    margin-left: 0.8rem;
   }
 `;
 
 export const Title = styled(Heading_5)`
   color: ${({ theme }) => theme.color.grey_200};
+`;
 
-  margin-bottom: 0.6rem;
+export const DropdownIcon = styled.img<{ toggle: boolean }>`
+  cursor: pointer;
+  transform: ${({ toggle }) => (toggle ? "rotate(180deg)" : "rotate(0)")};
 `;

--- a/src/pages/result/treatmentBox/index.tsx
+++ b/src/pages/result/treatmentBox/index.tsx
@@ -1,12 +1,22 @@
 import { ITreatBoxProps } from "src/interfaces/resultPage";
 import Description from "../description";
-import { Container, Title } from "./index.style";
+import { Container, Title, TitleContainer, DropdownIcon, TitleBox } from "./index.style";
+import TreatmentTag from "src/components/treatmentTag";
+import { useState } from "react";
 
-const TreatmentBox = ({ title, description }: ITreatBoxProps) => {
+const TreatmentBox = ({ title, type, description }: ITreatBoxProps) => {
+  const [toggle, setToggle] = useState(false);
+
   return (
     <Container>
-      <Title>{title}</Title>
-      <Description text={description} />
+      <TitleContainer>
+        <TitleBox>
+          <Title>{title}</Title>
+          <TreatmentTag type={type} />
+        </TitleBox>
+        <DropdownIcon src="/images/informationPage/dropdown.svg" alt="dropdown icon" toggle={toggle} onClick={() => setToggle(!toggle)} />
+      </TitleContainer>
+      {toggle && <Description text={description} />}
     </Container>
   );
 };

--- a/src/pages/result/treatmentBox/index.tsx
+++ b/src/pages/result/treatmentBox/index.tsx
@@ -8,13 +8,13 @@ const TreatmentBox = ({ title, type, description }: ITreatBoxProps) => {
   const [toggle, setToggle] = useState(false);
 
   return (
-    <Container>
+    <Container onClick={() => setToggle(!toggle)}>
       <TitleContainer>
         <TitleBox>
           <Title>{title}</Title>
           <TreatmentTag type={type} />
         </TitleBox>
-        <DropdownIcon src="/images/informationPage/dropdown.svg" alt="dropdown icon" toggle={toggle} onClick={() => setToggle(!toggle)} />
+        <DropdownIcon src="/images/informationPage/dropdown.svg" alt="dropdown icon" toggle={toggle} />
       </TitleContainer>
       {toggle && <Description text={description} />}
     </Container>

--- a/src/pages/result/treatmentPage/index.tsx
+++ b/src/pages/result/treatmentPage/index.tsx
@@ -7,10 +7,10 @@ const TreatmentPage = ({ treatData }: { treatData: ITreatPageProps[] }) => {
   return (
     <Container>
       <section className="title-box">
-        <Title text={"병원에 가면\n이런 치료를 받아요"} />
+        <Title text={"병원에 가면\n이런 검사 ・ 치료를 받아요"} />
       </section>
       {treatData.map((treat, idx) => (
-        <TreatmentBox key={idx} title={treat.title} description={treat.detail} />
+        <TreatmentBox key={idx} title={treat.title} description={treat.detail} type={treat.type} />
       ))}
     </Container>
   );


### PR DESCRIPTION
## 🛠 관련 이슈
- closes #81 

## 📝 작업 사항
- 지난번 회의때 전달받았던 결과페이지 UI를 수정했습니다.
- 진단 API 연동이 안되어있다보니 결과 페이지 작업하면서 백엔드측에서 mock데이터 받아서 작업했습니다.
- IDiagnosticResult type이 기존에 정의되어있던것과 달라서 결과 페이지 타입 몇 가지를 수정했습니다. (확정된 타입은 아닌 것 같아 추후 진단 API 연동할때 다시 한번 수정해야할 것 같습니다,,!)
- 임의로 치료, 검사 태그를 `type: therapy`, `type: inspection` 로 value 설정을 해뒀는데 나중에 백엔드 응답오는 것을 보고 수정해야할 것 같습니다.
