### PR TITLE
[Refactor] 공통 컴포넌트 리팩토링

### DIFF
--- a/src/components/button/index.stories.tsx
+++ b/src/components/button/index.stories.tsx
@@ -1,5 +1,5 @@
-import Button, { IButton } from ".";
-import { Meta, Story } from "@storybook/react";
+import Button from ".";
+import { Meta } from "@storybook/react";
 
 export default {
   component: Button,
@@ -14,16 +14,26 @@ export default {
   },
 } as Meta;
 
-const Template: Story<IButton> = (args) => <Button {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  selected: false,
-  children: "Button",
+export const Default = () => {
+  return <Button selected={false}>Button</Button>;
 };
 
-export const Selected = Template.bind({});
-Selected.args = {
-  selected: true,
-  children: "Button",
+export const Selected = () => {
+  return <Button selected>Button</Button>;
+};
+
+export const StyledDefaultButton = () => {
+  return (
+    <Button selected={false} style={{ width: "7.9rem", height: "4.4rem" }}>
+      Button
+    </Button>
+  );
+};
+
+export const StyledSelectButton = () => {
+  return (
+    <Button selected style={{ width: "7.9rem", height: "4.4rem" }}>
+      Button
+    </Button>
+  );
 };

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react";
 import { Container } from "./index.style";
 
-export interface IButton extends HTMLAttributes<HTMLDivElement> {
+export interface IButton extends HTMLAttributes<HTMLButtonElement> {
   selected: boolean;
   children: string;
 }

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,12 +1,17 @@
+import { HTMLAttributes } from "react";
 import { Container } from "./index.style";
 
-export interface IButton {
+export interface IButton extends HTMLAttributes<HTMLDivElement> {
   selected: boolean;
   children: string;
 }
 
-function Button({ selected, children }: IButton) {
-  return <Container selected={selected}>{children}</Container>;
+function Button({ selected, children, ...props }: IButton) {
+  return (
+    <Container selected={selected} {...props}>
+      {children}
+    </Container>
+  );
 }
 
 export default Button;

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react";
 import { Container } from "./index.style";
 
-export interface IButton extends HTMLAttributes<HTMLButtonElement> {
+export interface IButton extends HTMLAttributes<HTMLDivElement> {
   selected: boolean;
   children: string;
 }

--- a/src/components/layout/index.style.tsx
+++ b/src/components/layout/index.style.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const Container = styled.div<{ padding: string }>`
+  position: relative;
+  top: 5.6rem;
+
+  height: calc(100vh - 5.6rem);
+  padding: ${({ padding }) => padding};
+`;

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -2,11 +2,11 @@ import { HTMLAttributes, ReactNode } from "react";
 import { Container } from "./index.style";
 
 interface TLayoutProps extends HTMLAttributes<HTMLDivElement> {
-  padding: string;
+  padding?: string;
   children: ReactNode;
 }
 
-function Layout({ padding, children, ...props }: TLayoutProps) {
+function Layout({ padding = "0", children, ...props }: TLayoutProps) {
   return (
     <Container padding={padding} {...props}>
       {children}

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,0 +1,17 @@
+import { HTMLAttributes, ReactNode } from "react";
+import { Container } from "./index.style";
+
+interface TLayoutProps extends HTMLAttributes<HTMLDivElement> {
+  padding: string;
+  children: ReactNode;
+}
+
+function Layout({ padding, children, ...props }: TLayoutProps) {
+  return (
+    <Container padding={padding} {...props}>
+      {children}
+    </Container>
+  );
+}
+
+export default Layout;

--- a/src/components/tag/index.stories.tsx
+++ b/src/components/tag/index.stories.tsx
@@ -1,5 +1,6 @@
 import Tag, { ITag } from ".";
 import { Meta, Story } from "@storybook/react";
+import theme from "src/lib/theme";
 
 export default {
   component: Tag,
@@ -14,16 +15,18 @@ export default {
   },
 } as Meta;
 
-const Template: Story<ITag> = (args) => <Tag {...args} />;
-
-export const Default = Template.bind({});
-Default.args = {
-  selected: false,
-  children: "Tag",
+export const Default = () => {
+  return <Tag selected={false}>Tag</Tag>;
 };
 
-export const Selected = Template.bind({});
-Selected.args = {
-  selected: true,
-  children: "Tag",
+export const Selected = () => {
+  return <Tag selected>Tag</Tag>;
+};
+
+export const StyledPrimaryButton = () => {
+  return <Tag style={{ color: theme.color.grey_200, background: theme.color.blue }}>Tag</Tag>;
+};
+
+export const StyledDisabledButton = () => {
+  return <Tag style={{ color: theme.color.grey_200, background: theme.color.grey_500 }}>Tag</Tag>;
 };

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -1,12 +1,17 @@
+import { HTMLAttributes } from "react";
 import { Container } from "./index.style";
 
-export interface ITag {
+export interface ITag extends HTMLAttributes<HTMLButtonElement> {
   children: string;
-  selected: boolean;
+  selected?: boolean;
 }
 
-const Tag = ({ children, selected }: ITag) => {
-  return <Container selected={selected}>{children}</Container>;
+const Tag = ({ children, selected = false, ...props }: ITag) => {
+  return (
+    <Container selected={selected} {...props}>
+      {children}
+    </Container>
+  );
 };
 
 export default Tag;

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from "react";
 import { Container } from "./index.style";
 
-export interface ITag extends HTMLAttributes<HTMLButtonElement> {
+export interface ITag extends HTMLAttributes<HTMLDivElement> {
   children: string;
   selected?: boolean;
 }

--- a/src/pages/diagnosis/index.style.tsx
+++ b/src/pages/diagnosis/index.style.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { Heading_3, Body_1, Body_3 } from "src/lib/fontStyle";
 
 export const Container = styled.section`
-  height: calc(100vh - 5.6rem);
+  height: 100%;
   background: radial-gradient(300.02% 130.63% at 164.62% 165.58%, rgba(84, 100, 242, 0.9) 0%, rgba(52, 62, 135, 0) 100%) #131416;
   background-attachment: fixed;
 
@@ -12,8 +12,6 @@ export const Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  padding-top: 5.6rem;
 
   &::-webkit-scrollbar {
     display: none !important;

--- a/src/pages/diagnosis/index.tsx
+++ b/src/pages/diagnosis/index.tsx
@@ -1,5 +1,6 @@
 import { useLocation, useNavigate } from "react-router-dom";
 import ContentHeader from "src/components/contentHeader";
+import Layout from "src/components/layout";
 import Loading from "src/components/loading";
 import imageUrl from "src/data/image_url";
 import useDiagnosis from "src/hooks/diagnose/useDiagnosis";
@@ -32,7 +33,7 @@ const Diagnosis = () => {
           }
         />
       ) : (
-        <>
+        <Layout>
           <ContentHeader back={true} backCallback={handleBack} exit={true} exitCallback={() => navigate("/")}>
             감별진단
           </ContentHeader>
@@ -49,7 +50,7 @@ const Diagnosis = () => {
               handleNext={handleNext}
             />
           </Container>
-        </>
+        </Layout>
       )}
     </>
   );

--- a/src/pages/diagnosisList/index.style.tsx
+++ b/src/pages/diagnosisList/index.style.tsx
@@ -1,10 +1,6 @@
 import { Heading_3 } from "src/lib/fontStyle";
 import styled from "styled-components";
 
-export const Container = styled.div`
-  padding: 5.6rem 2.4rem;
-`;
-
 export const Title = styled(Heading_3)<{ margin: string }>`
   color: ${({ theme }) => theme.color.grey_200};
 

--- a/src/pages/diagnosisList/index.tsx
+++ b/src/pages/diagnosisList/index.tsx
@@ -2,8 +2,9 @@ import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import ContentHeader from "src/components/contentHeader";
 import DiagnosisCard, { IDiagnosisItem } from "src/components/diagnosisCard";
+import Layout from "src/components/layout";
 import { IDiagnosisResultList } from "src/interfaces/diagnosticResult";
-import { Container, List, Title } from "./index.style";
+import { List, Title } from "./index.style";
 
 const DiagnosisList = () => {
   const { state } = useLocation() as { state: IDiagnosisResultList };
@@ -27,31 +28,29 @@ const DiagnosisList = () => {
   };
 
   return (
-    <>
+    <Layout padding="0 2.4rem">
       <ContentHeader back={true} exit={true} backCallback={() => navigate(-1)} exitCallback={() => navigate("/")} />
-      <Container>
-        {state && (
-          <>
-            <Title margin="2rem 0 1.6rem 0">
-              가장 가능성 높은 질환은
-              <br />
-              <span className="highlight">{state.likely.record.title}</span>에요
-            </Title>
-            <DiagnosisCard isSquare diagnosis={state.likely} handleNavigate={() => handleNavigate(state.likely)} />
-            <Title margin="4rem 0 1.6rem 0">
-              가능성 높은
-              <br />
-              추가 질환을 알려드려요
-            </Title>
-            <List>
-              {state.predicted.map((diag, idx) => (
-                <DiagnosisCard key={idx} diagnosis={diag} handleNavigate={() => handleNavigate(diag)} />
-              ))}
-            </List>
-          </>
-        )}
-      </Container>
-    </>
+      {state && (
+        <>
+          <Title margin="2rem 0 1.6rem 0">
+            가장 가능성 높은 질환은
+            <br />
+            <span className="highlight">{state.likely.record.title}</span>에요
+          </Title>
+          <DiagnosisCard isSquare diagnosis={state.likely} handleNavigate={() => handleNavigate(state.likely)} />
+          <Title margin="4rem 0 1.6rem 0">
+            가능성 높은
+            <br />
+            추가 질환을 알려드려요
+          </Title>
+          <List>
+            {state.predicted.map((diag, idx) => (
+              <DiagnosisCard key={idx} diagnosis={diag} handleNavigate={() => handleNavigate(diag)} />
+            ))}
+          </List>
+        </>
+      )}
+    </Layout>
   );
 };
 

--- a/src/pages/information/index.style.tsx
+++ b/src/pages/information/index.style.tsx
@@ -2,13 +2,14 @@ import styled from "styled-components";
 import { Heading_3 } from "src/lib/fontStyle";
 
 export const ButtonBackground = styled.section`
+  width: 100%;
+
   position: fixed;
   bottom: 0;
-  margin: 0 2rem;
+  left: 0;
   font-size: 1.3rem;
 
-  padding-top: 10.4rem;
-  padding-bottom: 3rem;
+  padding: 10.4rem 2rem 3rem 2rem;
 
   background: linear-gradient(180deg, rgba(19, 20, 22, 0) 0%, rgba(19, 20, 22, 0.947917) 78.12%, #131416 100%);
 
@@ -23,11 +24,4 @@ export const Title = styled(Heading_3)`
   color: ${({ theme }) => theme.color.grey_200};
 
   padding-top: 4rem;
-`;
-
-export const Contents = styled.section`
-  margin: 0 2.4rem 15rem 2.4rem;
-  padding-top: 5.6rem;
-
-  height: (var(--vh, 1vh) * 100);
 `;

--- a/src/pages/information/index.tsx
+++ b/src/pages/information/index.tsx
@@ -51,32 +51,30 @@ const Information = () => {
   return (
     <>
       {agreementDetail === 0 ? (
-        <>
+        <Layout padding="0 2.4rem 15rem 2.4rem" style={{ height: "(var(--vh, 1vh) * 100)" }}>
           <ContentHeader back={false} exit={true} exitCallback={() => navigate("/")}>
             정보 수집
           </ContentHeader>
-          <Layout padding="0 2.4rem 15rem 2.4rem" style={{ height: "(var(--vh, 1vh) * 100)" }}>
-            <Title>
-              잠깐! <br />더 나은 감별 서비스를 위해
-              <br /> 간단한 정보가 필요해요
-            </Title>
-            <YearPicker year={year} setYear={setYear} />
-            <Gender gender={gender} setGender={setGender} />
-            <Tags health={health} setHealth={setHealth} />
-            <Agreement agree={agree} setAgree={setAgree} setAgreementDetail={setAgreementDetail} />
-            <ButtonBackground>
-              <section className="button-box" onClick={handleProceed}>
-                <RoundButton
-                  outline="none"
-                  backgroundColor={active ? theme.color.blue : theme.color.grey_750}
-                  color={active ? theme.color.grey_100 : theme.color.grey_600}
-                >
-                  증상 감별하러 가기
-                </RoundButton>
-              </section>
-            </ButtonBackground>
-          </Layout>
-        </>
+          <Title>
+            잠깐! <br />더 나은 감별 서비스를 위해
+            <br /> 간단한 정보가 필요해요
+          </Title>
+          <YearPicker year={year} setYear={setYear} />
+          <Gender gender={gender} setGender={setGender} />
+          <Tags health={health} setHealth={setHealth} />
+          <Agreement agree={agree} setAgree={setAgree} setAgreementDetail={setAgreementDetail} />
+          <ButtonBackground>
+            <section className="button-box" onClick={handleProceed}>
+              <RoundButton
+                outline="none"
+                backgroundColor={active ? theme.color.blue : theme.color.grey_750}
+                color={active ? theme.color.grey_100 : theme.color.grey_600}
+              >
+                증상 감별하러 가기
+              </RoundButton>
+            </section>
+          </ButtonBackground>
+        </Layout>
       ) : agreementDetail === 1 ? (
         <MemberAgreement agreementDetail={agreementDetail} setAgreementDetail={setAgreementDetail} />
       ) : (

--- a/src/pages/information/index.tsx
+++ b/src/pages/information/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import ContentHeader from "src/components/contentHeader";
+import Layout from "src/components/layout";
 import RoundButton from "src/components/roundButton";
 import { health_interest } from "src/data/interest";
 import { IAgreement } from "src/interfaces/informationPage";
@@ -9,7 +10,7 @@ import { useAppDispatch } from "src/state";
 import { userSubmit } from "src/state/userSlice";
 import Agreement from "./agreement";
 import Gender from "./gender";
-import { Contents, Title, ButtonBackground } from "./index.style";
+import { Title, ButtonBackground } from "./index.style";
 import InformationAgreement from "./informationAgreement";
 import MemberAgreement from "./memberAgreement";
 import Tags from "./tags";
@@ -54,7 +55,7 @@ const Information = () => {
           <ContentHeader back={false} exit={true} exitCallback={() => navigate("/")}>
             정보 수집
           </ContentHeader>
-          <Contents>
+          <Layout padding="0 2.4rem 15rem 2.4rem" style={{ height: "(var(--vh, 1vh) * 100)" }}>
             <Title>
               잠깐! <br />더 나은 감별 서비스를 위해
               <br /> 간단한 정보가 필요해요
@@ -63,18 +64,18 @@ const Information = () => {
             <Gender gender={gender} setGender={setGender} />
             <Tags health={health} setHealth={setHealth} />
             <Agreement agree={agree} setAgree={setAgree} setAgreementDetail={setAgreementDetail} />
-          </Contents>
-          <ButtonBackground>
-            <section className="button-box" onClick={handleProceed}>
-              <RoundButton
-                outline="none"
-                backgroundColor={active ? theme.color.blue : theme.color.grey_750}
-                color={active ? theme.color.grey_100 : theme.color.grey_600}
-              >
-                증상 감별하러 가기
-              </RoundButton>
-            </section>
-          </ButtonBackground>
+            <ButtonBackground>
+              <section className="button-box" onClick={handleProceed}>
+                <RoundButton
+                  outline="none"
+                  backgroundColor={active ? theme.color.blue : theme.color.grey_750}
+                  color={active ? theme.color.grey_100 : theme.color.grey_600}
+                >
+                  증상 감별하러 가기
+                </RoundButton>
+              </section>
+            </ButtonBackground>
+          </Layout>
         </>
       ) : agreementDetail === 1 ? (
         <MemberAgreement agreementDetail={agreementDetail} setAgreementDetail={setAgreementDetail} />

--- a/src/pages/main/index.style.tsx
+++ b/src/pages/main/index.style.tsx
@@ -1,20 +1,11 @@
 import { Heading_3 } from "src/lib/fontStyle";
 import styled from "styled-components";
 
-export const Container = styled.main`
-  padding-top: 5.6rem;
-  height: calc(var(--vh, 1vh) * 100 - 9.6rem);
-
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
+export const Title = styled(Heading_3)`
+  padding-top: 4rem;
+  padding-left: 2.4rem;
 
   color: ${({ theme }) => theme.color.grey_100};
-`;
-
-export const Title = styled(Heading_3)`
-  margin-top: 4rem;
-  margin-left: 2.4rem;
 
   .strong {
     font-weight: 500;

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -10,21 +10,19 @@ const MainPage = () => {
   const { isOpenModal, modalRef, openModal, closeModal } = useModal();
 
   return (
-    <>
+    <Layout>
       <MainHeader />
-      <Layout padding="0">
-        <Title>
-          <span className="strong">빠른 증상감별</span>로
-          <br />
-          <span className="strong">예상 질환</span>을 알아보세요!
-        </Title>
-        <MainImage>
-          <img className="image" alt="main" src={imageUrl.main_page}></img>
-        </MainImage>
-        <BottomButtons openModal={openModal} />
-        {isOpenModal && <MainModal ref={modalRef} closeModal={closeModal} />}
-      </Layout>
-    </>
+      <Title>
+        <span className="strong">빠른 증상감별</span>로
+        <br />
+        <span className="strong">예상 질환</span>을 알아보세요!
+      </Title>
+      <MainImage>
+        <img className="image" alt="main" src={imageUrl.main_page}></img>
+      </MainImage>
+      <BottomButtons openModal={openModal} />
+      {isOpenModal && <MainModal ref={modalRef} closeModal={closeModal} />}
+    </Layout>
   );
 };
 

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,8 +1,9 @@
+import Layout from "src/components/layout";
 import MainHeader from "src/components/mainHeader";
 import imageUrl from "src/data/image_url";
 import useModal from "src/hooks/useModal";
 import BottomButtons from "./bottomButtons";
-import { Container, Title, MainImage } from "./index.style";
+import { Title, MainImage } from "./index.style";
 import MainModal from "./mainModal";
 
 const MainPage = () => {
@@ -11,7 +12,7 @@ const MainPage = () => {
   return (
     <>
       <MainHeader />
-      <Container>
+      <Layout padding="0">
         <Title>
           <span className="strong">빠른 증상감별</span>로
           <br />
@@ -22,7 +23,7 @@ const MainPage = () => {
         </MainImage>
         <BottomButtons openModal={openModal} />
         {isOpenModal && <MainModal ref={modalRef} closeModal={closeModal} />}
-      </Container>
+      </Layout>
     </>
   );
 };

--- a/src/pages/myDiagnosis/index.style.tsx
+++ b/src/pages/myDiagnosis/index.style.tsx
@@ -1,10 +1,6 @@
 import { Description, Heading_3 } from "src/lib/fontStyle";
 import styled from "styled-components";
 
-export const Container = styled.section`
-  padding-top: 5.6rem;
-`;
-
 export const ButtonBackground = styled.section`
   position: fixed;
   bottom: 0;

--- a/src/pages/myDiagnosis/index.tsx
+++ b/src/pages/myDiagnosis/index.tsx
@@ -2,13 +2,14 @@ import { useLayoutEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Diagnosis } from "src/api/diagnosis";
 import DiagnosisCard, { IDiagnosisItem } from "src/components/diagnosisCard";
+import Layout from "src/components/layout";
 import MainHeader from "src/components/mainHeader";
 import RoundButton from "src/components/roundButton";
 import theme from "src/lib/theme";
 import { useAppSelector, useAppDispatch } from "src/state";
 import { DELETE_TOKEN } from "src/state/authSlice";
 import EmptyPage from "./emptyList";
-import { Container, Title, DescriptionBox, List, ButtonBackground } from "./index.style";
+import { Title, DescriptionBox, List, ButtonBackground } from "./index.style";
 
 const MyDiagnosis = () => {
   const navigate = useNavigate();
@@ -47,7 +48,7 @@ const MyDiagnosis = () => {
   };
 
   return (
-    <Container>
+    <Layout>
       <MainHeader />
       {loading || (
         <>
@@ -79,7 +80,7 @@ const MyDiagnosis = () => {
           </RoundButton>
         </section>
       </ButtonBackground>
-    </Container>
+    </Layout>
   );
 };
 

--- a/src/pages/symptomType/index.style.tsx
+++ b/src/pages/symptomType/index.style.tsx
@@ -9,8 +9,6 @@ export const Container = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  padding: 5.6rem 2rem 0 2rem;
 `;
 
 export const Title = styled(Heading_3)`

--- a/src/pages/symptomType/index.tsx
+++ b/src/pages/symptomType/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import ContentHeader from "src/components/contentHeader";
+import Layout from "src/components/layout";
 import RoundButton from "src/components/roundButton";
 import useModal from "src/hooks/useModal";
 import theme from "src/lib/theme";
@@ -43,11 +44,12 @@ const SymptomTypePage = () => {
   }, [isOpenModal]);
 
   return (
-    <>
+    <Layout>
       {isOpenModal && <SymptomTypeModal ref={modalRef} closeModal={closeModal} select={select} />}
       <ContentHeader back={true} backCallback={() => navigate(-1)} exit={true} exitCallback={() => navigate("/")}>
         증상 유형 선택
       </ContentHeader>
+
       <Container>
         <Title>
           증상 유형을
@@ -59,14 +61,18 @@ const SymptomTypePage = () => {
           </SymptomContainer>
         ))} */}
         {symptomTypes.map((type) => (
-          <div key={type.state} onClick={() => navigate("/diagnosis", { state: type.state })}>
-            <RoundButton outline={theme.color.blue} backgroundColor={theme.color.blue} color={theme.color.green_100}>
-              {type.text}
-            </RoundButton>
-          </div>
+          <RoundButton
+            key={type.state}
+            outline={theme.color.blue}
+            backgroundColor={theme.color.blue}
+            color={theme.color.green_100}
+            onClick={() => navigate("/diagnosis", { state: type.state })}
+          >
+            {type.text}
+          </RoundButton>
         ))}
       </Container>
-    </>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## 🛠 관련 이슈
- closes #103 

## 📝 작업 사항
- 추가로 나오는 페이지들을 보니까 이전 공통 컴포넌트들이 사용하기 어렵게 구성되어있는 것 같아 일부 속성을 수정했습니다.
- `Button` 컴포넌트와 `Tag` 컴포넌트의 props 자유도를 높였습니다.
- `Layout` 컴포넌트를 만들어 header를 위한 padding 선언 반복을 줄였습니다.
