### PR TITLE
[Feat] 챌린지 상세 페이지 마크업 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
           <Route path="/qr/info" element={<Pages.InformationQR />} />
           <Route path="/qr/symptom-type" element={<Pages.SymptomTypeQR />} />
           <Route path="/qr/complete" element={<Pages.CompleteQR />} />
+          <Route path="/challenge/:id" element={<Pages.ChallengeDetail />} />
           <Route path="/test" element={<Pages.Test />} />
           <Route path="/*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/src/components/contentHeader/index.style.tsx
+++ b/src/components/contentHeader/index.style.tsx
@@ -1,5 +1,20 @@
 import styled from "styled-components";
 
+export const RootContainer = styled.header<{ borderBottom: boolean }>`
+  position: fixed;
+  width: inherit;
+  top: 0;
+
+  height: 5.6rem;
+  letter-spacing: 0.015rem;
+
+  border-bottom: ${({ theme, borderBottom }) => (borderBottom ? `0.5px solid ${theme.color.grey_800}` : "none")}
+
+  background: transparent;
+
+  z-index: 3;
+`;
+
 export const Container = styled.section`
   color: ${({ theme }) => theme.color.grey_200};
   height: inherit;

--- a/src/components/contentHeader/index.tsx
+++ b/src/components/contentHeader/index.tsx
@@ -1,5 +1,5 @@
-import HeaderContainer from "../headerContainer";
-import { Container, BackButton, ExitButton } from "./index.style";
+import { useNavigate } from "react-router-dom";
+import { RootContainer, Container, BackButton, ExitButton } from "./index.style";
 
 export interface IContentHeader {
   label?: string;
@@ -7,13 +7,16 @@ export interface IContentHeader {
   exit: boolean;
   backCallback?: () => void;
   exitCallback?: () => void;
+  borderBottom?: boolean;
 }
 
-const ContentHeader = ({ label = "", back, exit, backCallback, exitCallback }: IContentHeader) => {
+const ContentHeader = ({ label = "", back, exit, backCallback, exitCallback, borderBottom = true }: IContentHeader) => {
+  const navigate = useNavigate();
+
   return (
-    <HeaderContainer>
+    <RootContainer borderBottom={borderBottom}>
       <Container>
-        <BackButton visible={back} onClick={() => backCallback && backCallback()}>
+        <BackButton visible={back} onClick={() => (backCallback ? backCallback() : navigate(-1))}>
           {back && <img alt="back" src="/images/header/back.svg" width={32} height={32} />}
         </BackButton>
         <section className="title">{label}</section>
@@ -21,7 +24,7 @@ const ContentHeader = ({ label = "", back, exit, backCallback, exitCallback }: I
           {exit && <img alt="exit" src="/images/header/exit.svg" width={32} height={32} />}
         </ExitButton>
       </Container>
-    </HeaderContainer>
+    </RootContainer>
   );
 };
 

--- a/src/components/divider/index.style.tsx
+++ b/src/components/divider/index.style.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const StyledDivider = styled.div`
+  width: 100%;
+  height: 8px;
+  background-color: #1e2127;
+`;

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -1,0 +1,9 @@
+import { StyledDivider } from "./index.style";
+
+type TDivider = React.HTMLAttributes<HTMLDivElement>;
+
+function Divider(props: TDivider) {
+  return <StyledDivider {...props} />;
+}
+
+export default Divider;

--- a/src/components/flexBox/index.tsx
+++ b/src/components/flexBox/index.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+
+interface IStyledFlexBox {
+  flexDirection?: "column" | "row";
+  justifyContent?: "start" | "center" | "space-between" | "space-around" | "space-evenly";
+  alignItems?: "stretch" | "center" | "start" | "end";
+  gap?: string;
+  mt?: string;
+  mb?: string;
+}
+
+interface IFlexBoxProps extends IStyledFlexBox {
+  children?: React.ReactNode;
+}
+
+function FlexBox({ children, ...props }: IFlexBoxProps) {
+  return <StyledFlexBox {...props}>{children}</StyledFlexBox>;
+}
+
+export default FlexBox;
+
+const StyledFlexBox = styled.div<IStyledFlexBox>`
+  display: flex;
+
+  flex-direction: ${({ flexDirection = "row" }) => flexDirection};
+  justify-content: ${({ justifyContent = "start" }) => justifyContent};
+  align-items: ${({ alignItems = "stretch" }) => alignItems};
+
+  gap: ${({ gap }) => gap};
+
+  margin-top: ${({ mt }) => mt};
+  margin-bottom: ${({ mb }) => mb};
+`;

--- a/src/pages/challenge-detail/challenge-description/index.style.tsx
+++ b/src/pages/challenge-detail/challenge-description/index.style.tsx
@@ -1,0 +1,24 @@
+import { Heading_5 } from "src/lib/fontStyle";
+import styled from "styled-components";
+
+export const Container = styled.div`
+  margin-top: 5rem;
+`;
+
+export const Divider = styled.div`
+  width: 24px;
+  height: 2px;
+  background-color: #d2fa64;
+  margin-bottom: 1.2rem;
+`;
+
+export const Title = styled(Heading_5)`
+  .highlight {
+    color: #d2fa64;
+    font-weight: 500;
+  }
+
+  color: ${({ theme }) => theme.color.grey_200};
+  font-weight: 300;
+  margin-bottom: 1.2rem;
+`;

--- a/src/pages/challenge-detail/challenge-description/index.tsx
+++ b/src/pages/challenge-detail/challenge-description/index.tsx
@@ -1,0 +1,22 @@
+import * as Styled from "./index.style";
+
+interface IChallengeDescription {
+  title?: string;
+  highlight: string;
+  children?: React.ReactNode;
+}
+
+function ChallengeDescription({ title, highlight, children }: IChallengeDescription) {
+  return (
+    <Styled.Container>
+      <Styled.Divider />
+      <Styled.Title>
+        <span className="highlight">{highlight}</span>
+        {title}
+      </Styled.Title>
+      {children}
+    </Styled.Container>
+  );
+}
+
+export default ChallengeDescription;

--- a/src/pages/challenge-detail/index.style.tsx
+++ b/src/pages/challenge-detail/index.style.tsx
@@ -1,0 +1,100 @@
+import { Heading_2 } from "src/lib/fontStyle";
+import styled from "styled-components";
+
+export const Container = styled.main`
+  width: 100%;
+`;
+
+export const Image = styled.div<{ src: string }>`
+  position: relative;
+
+  width: 100%;
+  padding-top: 80%;
+  background-size: cover;
+
+  ::before {
+    content: "";
+
+    display: block;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    width: 100%;
+    height: 100%;
+
+    background-image: ${({ src }) => `url(${src})`};
+    background-size: cover;
+  }
+`;
+
+export const ImageShadow = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+
+  width: 100%;
+  height: 50%;
+
+  background: linear-gradient(0deg, #131416 0%, rgba(19, 20, 22, 0) 100%);
+`;
+
+export const Section = styled.section`
+  padding: 0 2rem;
+`;
+
+export const Typography = styled.p<{
+  mt?: string;
+  mb?: string;
+  color?: "200" | "300" | "500";
+  lineHeight?: "140%" | "150%";
+  fontSize?: string;
+}>`
+  .highlight {
+    color: ${({ theme }) => theme.color.blue_500};
+  }
+
+  font-size: ${({ fontSize = "1.4rem" }) => fontSize};
+  font-weight: 200;
+
+  margin-top: ${({ mt }) => mt};
+  margin-bottom: ${({ mb }) => mb};
+  color: ${({ color = "200", theme }) =>
+    color === "200" ? theme.color.grey_200 : color === "300" ? theme.color.grey_300 : theme.color.grey_500};
+  line-height: ${({ lineHeight = "140%" }) => lineHeight};
+`;
+
+export const Title = styled(Heading_2)`
+  color: ${({ theme }) => theme.color.grey_200};
+
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+`;
+
+export const Chip = styled.div<{ variant: "primary" | "secondary" }>`
+  font-size: 1.2rem;
+
+  font-weight: ${({ variant }) => (variant === "primary" ? "200" : "300")};
+  padding: ${({ variant }) => (variant === "primary" ? "4px 8px" : "5px 10px")};
+  border-radius: ${({ variant }) => (variant === "primary" ? "8px" : "4px")};
+  color: ${({ variant, theme }) => (variant === "primary" ? theme.color.green_300 : theme.color.sub_blue)};
+  background-color: ${({ variant }) => (variant === "primary" ? "#E6FAAF26" : "#5464F233")};
+`;
+
+export const Button = styled.button`
+  width: 100%;
+  padding: 1.4rem 6.2rem;
+
+  border-radius: 8px;
+  background: ${({ theme }) => theme.color.blue};
+
+  font-size: 1.4rem;
+  color: ${({ theme }) => theme.color.grey_100};
+  font-weight: 300;
+  line-height: 150%;
+
+  cursor: pointer;
+
+  margin-bottom: 2.4rem;
+`;

--- a/src/pages/challenge-detail/index.tsx
+++ b/src/pages/challenge-detail/index.tsx
@@ -1,0 +1,86 @@
+import ContentHeader from "src/components/contentHeader";
+import Divider from "src/components/divider";
+import FlexBox from "src/components/flexBox";
+import ChallengeDescription from "./challenge-description";
+import * as Styled from "./index.style";
+
+function ChallengeDetail() {
+  const handleClickParticipateButton = () => {
+    alert("TODO: 참여하기 페이지");
+  };
+
+  return (
+    <>
+      <ContentHeader back={true} exit={false} borderBottom={false} />
+      <Styled.Container>
+        <Styled.Image src="https://images.unsplash.com/photo-1607077792448-17b60bcca65f?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=3456&q=80">
+          <Styled.ImageShadow />
+        </Styled.Image>
+
+        <Styled.Section>
+          <FlexBox flexDirection="column" mt="4rem" mb="3.2rem" alignItems="center">
+            <Styled.Typography>
+              <span className="highlight">34명</span>이 참여하고 있어요!
+            </Styled.Typography>
+
+            <Styled.Title>매일 아침 공복에 유산균 먹기</Styled.Title>
+
+            <FlexBox flexDirection="row" gap="1rem">
+              <Styled.Chip variant="primary">매일 인증</Styled.Chip>
+              <Styled.Chip variant="primary">28일 동안</Styled.Chip>
+              <Styled.Chip variant="primary">사진 인증</Styled.Chip>
+            </FlexBox>
+          </FlexBox>
+
+          <FlexBox flexDirection="column" gap="1.2rem" mt="3.2rem" mb="1.6rem">
+            <FlexBox gap="1.2rem" alignItems="center">
+              <Styled.Chip variant="secondary">Midterm 보상</Styled.Chip>
+              <Styled.Typography color="300" lineHeight="150%">
+                3천원 상품권
+              </Styled.Typography>
+            </FlexBox>
+
+            <FlexBox gap="1.2rem" alignItems="center">
+              <Styled.Chip variant="secondary">Final 보상</Styled.Chip>
+              <Styled.Typography color="300" lineHeight="150%">
+                5천원 상품권
+              </Styled.Typography>
+            </FlexBox>
+          </FlexBox>
+
+          <Styled.Typography fontSize="1.2rem" color="500" mb="2.4rem">
+            상품권 제휴사는 전국 5대 편의점 (CU, GS25, 7-Eleven, Ministop, emart24)/교보문고/CGV/다이소/네이버페이 중 선택 가능합니다.
+          </Styled.Typography>
+
+          <Styled.Button onClick={handleClickParticipateButton}>참여하기</Styled.Button>
+        </Styled.Section>
+
+        <Divider />
+
+        <Styled.Section>
+          <ChallengeDescription highlight="WHAT : " title="무엇을 하는 챌린지인가요?">
+            <Styled.Typography color="300" lineHeight="150%">
+              매일 아침에 일어나자마자 공복상태로 유산균을 복용하는 챌린지예요.
+            </Styled.Typography>
+          </ChallengeDescription>
+
+          <ChallengeDescription highlight="WHY : " title="왜 이 챌린지를 해야하나요?">
+            <Styled.Typography color="300" lineHeight="150%">
+              장내 미생물은 인간의 몸속에 공존하면서 생체대사 조절과 소화능력, 그리고 각종 질병의 조절 등에 영향을 미쳐요. 유산균 제제는
+              장내 미생물의 균형을 유지하고 유익한 미생물을 증식시켜요.
+            </Styled.Typography>
+          </ChallengeDescription>
+
+          <ChallengeDescription highlight="TIP : " title="언제 먹는 것이 좋나요?">
+            <Styled.Typography color="300" lineHeight="150%">
+              아침 공복에 먹는 것이 좋아요. 공복에 먹어야 위산이 나와 유산균 제제의 활성이 떨어지는 것을 막을 수 있어요. 만약 공복에 먹는
+              것을 깜빡 잊었다면 위산 분비가 적은 식후 30분 이후에 먹는 것이 좋아요.
+            </Styled.Typography>
+          </ChallengeDescription>
+        </Styled.Section>
+      </Styled.Container>
+    </>
+  );
+}
+
+export default ChallengeDetail;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import Appointment from "./appointment";
+import ChallengeDetail from "./challenge-detail";
 import CompleteQR from "./complete-qr";
 import Diagnosis from "./diagnosis";
 import DiagnosisList from "./diagnosisList";
@@ -32,4 +33,5 @@ export {
   SymptomTypeQR,
   CompleteQR,
   IndexQR,
+  ChallengeDetail,
 };


### PR DESCRIPTION
## 🛠 관련 이슈
- resolves #134 

## 📝 작업 사항
- 챌린지 상세 페이지의 마크업을 구현했습니다.
- `display: flex;` 의 재사용성을 높이기 위해 `FlexBox` 컴포넌트를 만들었습니다.
- `<contentHeader />` 컴포넌트에서 뒤로가기 버튼의 `default callback`을 추가했습니다.
