### PR TITLE
[Feat] 건강 기록장 구현

### DIFF
--- a/src/hooks/account/useLogout.ts
+++ b/src/hooks/account/useLogout.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { logout as logoutAPI } from "src/api/account/service";
 import { useAppDispatch } from "src/state";
@@ -8,6 +9,7 @@ import { removeCookie } from "src/utils/cookies";
 export const useLogout = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { mutate: logout } = useMutation({
     mutationFn: () => logoutAPI(),
@@ -16,6 +18,7 @@ export const useLogout = () => {
       removeCookie("accessToken");
       removeCookie("refreshToken");
       dispatch(logoutAction());
+      queryClient.clear();
 
       navigate("/");
     },

--- a/src/hooks/diagnosis/useGetRecords.ts
+++ b/src/hooks/diagnosis/useGetRecords.ts
@@ -1,22 +1,31 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { diagnosisFetcher } from "src/api/diagnosis/fetcher";
 import { queryKeys } from "src/api/queryKeys";
-import type { IDiagnosisRecordsRequest, IDiagnosisRecordsResponse } from "src/interfaces/diagnoseApi/records";
+import type { IDiagnosisRecordsResponse } from "src/interfaces/diagnoseApi/records";
 import type { IAuthState } from "src/state";
 
-const DEFAULT_RECORDS_DATA: IDiagnosisRecordsResponse = {
-  total: 0,
-  data: [],
-};
+export const useGetRecords = ({ size, authenticated }: { size: number } & Pick<IAuthState, "authenticated">) => {
+  const {
+    data: recordsData,
+    fetchNextPage,
+    hasNextPage,
+  } = useInfiniteQuery({
+    queryKey: [queryKeys, size],
+    queryFn: ({ pageParam = 0 }) => diagnosisFetcher.getRecords({ page: pageParam as number, size }),
+    getNextPageParam: (lastPage: IDiagnosisRecordsResponse, _, lastPageParam) => {
+      if (lastPage.total === 0) {
+        return undefined;
+      }
 
-export const useGetRecords = ({ page, size, authenticated }: IDiagnosisRecordsRequest & Pick<IAuthState, "authenticated">) => {
-  const { data: recordsData } = useQuery({
-    queryKey: [queryKeys, page, size],
-    queryFn: () => diagnosisFetcher.getRecords({ page, size }),
+      return lastPageParam + 1;
+    },
+    defaultPageParam: 0,
     enabled: authenticated,
   });
 
   return {
-    recordsData: recordsData ?? DEFAULT_RECORDS_DATA,
+    recordsData: recordsData?.pages ?? [],
+    fetchNextPage,
+    hasNextPage,
   };
 };

--- a/src/hooks/diagnosis/useGetRecords.ts
+++ b/src/hooks/diagnosis/useGetRecords.ts
@@ -6,7 +6,7 @@ import type { IAuthState } from "src/state";
 
 const DEFAULT_RECORDS_DATA: IDiagnosisRecordsResponse = {
   total: 0,
-  data: {},
+  data: [],
 };
 
 export const useGetRecords = ({ page, size, authenticated }: IDiagnosisRecordsRequest & Pick<IAuthState, "authenticated">) => {

--- a/src/interfaces/diagnoseApi/records.ts
+++ b/src/interfaces/diagnoseApi/records.ts
@@ -3,7 +3,22 @@ export interface IDiagnosisRecordsRequest {
   size: number;
 }
 
+interface IDX {
+  dxId: number;
+  dxName: string;
+}
+
+export interface IDiagnosisRecord {
+  createdAt: string;
+  dxList: IDX[];
+}
+
+export interface IDiagnosisRecords {
+  month: string;
+  records: IDiagnosisRecord[];
+}
+
 export interface IDiagnosisRecordsResponse {
-  data: any;
+  data: IDiagnosisRecords[];
   total: number;
 }

--- a/src/pages/account/diagnose-record/index.style.tsx
+++ b/src/pages/account/diagnose-record/index.style.tsx
@@ -73,6 +73,7 @@ export const DiagnoseCard = styled.div`
     flex-direction: row;
     justify-content: flex-start;
     gap: 0.6rem;
+    flex-wrap: wrap;
   }
 `;
 

--- a/src/pages/account/diagnose-record/index.tsx
+++ b/src/pages/account/diagnose-record/index.tsx
@@ -1,9 +1,25 @@
+import { useEffect } from "react";
+import { useInView } from "react-intersection-observer";
 import { useNavigate } from "react-router-dom";
 import { ChevronRightIcon } from "src/assets/icons/ChevronRightIcon";
+import { useGetRecords } from "src/hooks/diagnosis/useGetRecords";
 import theme from "src/lib/theme";
+import { useAppSelector } from "src/state";
 import * as Styled from "./index.style";
 
 const DiagnoseRecord = () => {
+  const { authenticated } = useAppSelector((state) => state.auth);
+
+  const [intersectionRef, inView] = useInView();
+
+  const { recordsData, fetchNextPage, hasNextPage } = useGetRecords({ size: 15, authenticated });
+
+  useEffect(() => {
+    if (inView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage, hasNextPage]);
+
   return (
     <>
       <Styled.Container>
@@ -12,29 +28,35 @@ const DiagnoseRecord = () => {
           <br />볼 수 있어요
         </Styled.Typography>
         <Styled.MainContent>
-          <Styled.MonthWrapper>
-            <Styled.MonthTitle>
-              <Styled.Typography className="monthly">7월 증상감별 내역</Styled.Typography>
-              <Styled.Typography className="record">
-                <Styled.Typography className="highlight">3개</Styled.Typography>의 기록
-              </Styled.Typography>
-            </Styled.MonthTitle>
-            {Array(8)
-              .fill(0)
-              .map((_, index) => (
-                <Styled.DiagnoseCard key={index}>
-                  <div className="topArea">
-                    <Styled.Typography className="cardMainText">7월 26일 기록</Styled.Typography>
-                    <ChevronRightIcon width={24} height={24} strokeWidth={2} stroke={theme.color.grey_500} />
-                  </div>
-                  <div className="bottomArea">
-                    <Styled.Chip>갑상선 기능 항진증</Styled.Chip>
-                    <Styled.Chip>양안 부동시</Styled.Chip>
-                    <Styled.Chip>식중독</Styled.Chip>
-                  </div>
-                </Styled.DiagnoseCard>
-              ))}
-          </Styled.MonthWrapper>
+          {recordsData.map(({ data }) =>
+            data.map(({ month, records }) => (
+              <Styled.MonthWrapper key={month}>
+                <Styled.MonthTitle>
+                  <Styled.Typography className="monthly">{month.split("-").at(-1)}월 증상감별 내역</Styled.Typography>
+                  <Styled.Typography className="record">
+                    <Styled.Typography className="highlight">{records.length}개</Styled.Typography>의 기록
+                  </Styled.Typography>
+                </Styled.MonthTitle>
+                {records.map(({ createdAt, dxList }) => (
+                  <Styled.DiagnoseCard key={createdAt}>
+                    <div className="topArea">
+                      <Styled.Typography className="cardMainText">
+                        {new Date(createdAt).getMonth() + 1}월 {new Date(createdAt).getDate()}일 증상 감별 내역
+                      </Styled.Typography>
+                      <ChevronRightIcon width={24} height={24} strokeWidth={2} stroke={theme.color.grey_500} />
+                    </div>
+
+                    <div className="bottomArea">
+                      {dxList.map(({ dxId, dxName }) => (
+                        <Styled.Chip key={dxId}>{dxName}</Styled.Chip>
+                      ))}
+                    </div>
+                  </Styled.DiagnoseCard>
+                ))}
+              </Styled.MonthWrapper>
+            ))
+          )}
+          <div ref={intersectionRef}></div>
         </Styled.MainContent>
       </Styled.Container>
       <Styled.BottomShadowArea />

--- a/src/pages/challenge-detail/index.style.tsx
+++ b/src/pages/challenge-detail/index.style.tsx
@@ -122,8 +122,16 @@ export const Chip = styled.div<{ variant: "primary" | "secondary" | "sub" }>`
   background-color: ${({ variant }) => (variant === "primary" ? "#E6FAAF26" : variant === "secondary" ? "#5464F233" : "#23272E")};
 `;
 
+export const ButtonWrapper = styled.div`
+  width: inherit;
+  padding: 2rem;
+  position: fixed;
+  bottom: 0;
+  box-sizing: border-box;
+`;
+
 export const Button = styled.button`
-  width: calc(100% - 4rem);
+  width: 100%;
   padding: 1.4rem 6.2rem;
 
   border-radius: 3rem;
@@ -135,8 +143,4 @@ export const Button = styled.button`
   line-height: 150%;
 
   cursor: pointer;
-
-  position: fixed;
-  bottom: 3.2rem;
-  transform: translateX(2rem);
 `;

--- a/src/pages/challenge-detail/index.tsx
+++ b/src/pages/challenge-detail/index.tsx
@@ -218,7 +218,9 @@ const ChallengeDetail = () => {
         </Styled.Section>
         <ChallengeNotification />
       </Styled.Container>
-      <Styled.Button onClick={handleClickParticipateButton}>참여하기</Styled.Button>
+      <Styled.ButtonWrapper>
+        <Styled.Button onClick={handleClickParticipateButton}>참여하기</Styled.Button>
+      </Styled.ButtonWrapper>
 
       {confirmDialogIsOpen && (
         <Dialog

--- a/src/pages/main/diagnosis-history/index.tsx
+++ b/src/pages/main/diagnosis-history/index.tsx
@@ -56,7 +56,7 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
               ))}
             </FlexBox>
           </Card>
-          <Link to="/account">
+          <Link to="/account/diagRecord">
             <Styled.Box>
               <FlexBox alignItems="center" justifyContent="space-between">
                 <p className="view-history">이전 기록 보러 가기</p>

--- a/src/pages/main/diagnosis-history/index.tsx
+++ b/src/pages/main/diagnosis-history/index.tsx
@@ -13,22 +13,19 @@ import type { IDiagnosisRecord } from "src/interfaces/diagnoseApi/records";
 import type { IAuthState } from "src/state";
 
 function DiagnosisHistory({ authenticated }: IAuthState) {
-  const { recordsData } = useGetRecords({
-    page: 0,
-    size: 15,
-    authenticated,
-  });
+  const { recordsData } = useGetRecords({ size: 15, authenticated });
+
   const [record, setRecord] = useState<IDiagnosisRecord>({
     createdAt: "",
     dxList: [],
   });
 
   useEffect(() => {
-    if (recordsData.total === 0) {
+    if (recordsData.length === 0 || recordsData[0].total === 0) {
       return;
     }
 
-    const latestMonthData = recordsData.data[0].records;
+    const latestMonthData = recordsData[0].data[0].records;
     const { createdAt, dxList } = latestMonthData[latestMonthData.length - 1];
 
     setRecord({
@@ -40,7 +37,7 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
   return (
     <Box>
       <Title text="🗂 나의 건강기록장" />
-      {recordsData.total === 0 ? (
+      {recordsData.length === 0 ? (
         <StartContents
           text={"증상 감별 내역이 없어요.\n빠른 증상감별로 예상질환을 확인해보세요!"}
           buttonText="증상 감별하러 가기"
@@ -59,7 +56,6 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
               ))}
             </FlexBox>
           </Card>
-          {/* TODO: 마이페이지 건강 기록장 path 연결 필요 */}
           <Link to="/account">
             <Styled.Box>
               <FlexBox alignItems="center" justifyContent="space-between">

--- a/src/pages/main/diagnosis-history/index.tsx
+++ b/src/pages/main/diagnosis-history/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { ChevronRightIcon } from "src/assets/icons/ChevronRightIcon";
 import FlexBox from "src/components/flexBox";
@@ -8,6 +9,7 @@ import { Box } from "../index.style";
 import StartContents from "../lib/StartContents";
 import Title from "../lib/Title";
 import * as Styled from "./index.style";
+import type { IDiagnosisRecord } from "src/interfaces/diagnoseApi/records";
 import type { IAuthState } from "src/state";
 
 function DiagnosisHistory({ authenticated }: IAuthState) {
@@ -16,6 +18,24 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
     size: 15,
     authenticated,
   });
+  const [record, setRecord] = useState<IDiagnosisRecord>({
+    createdAt: "",
+    dxList: [],
+  });
+
+  useEffect(() => {
+    if (recordsData.total === 0) {
+      return;
+    }
+
+    const latestMonthData = recordsData.data[0].records;
+    const { createdAt, dxList } = latestMonthData[latestMonthData.length - 1];
+
+    setRecord({
+      createdAt: new Date(createdAt).getMonth() + 1 + "월 " + new Date(createdAt).getDate() + "일",
+      dxList,
+    });
+  }, [recordsData]);
 
   return (
     <Box>
@@ -27,17 +47,16 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
           buttonHref={authenticated ? "/symptom-type" : "/info"}
         />
       ) : (
-        /* TODO: 건강 기록 API 연결 */
         <>
           <Card>
             <FlexBox alignItems="center" justifyContent="space-between" mb="12px">
-              <CardTitle>7월 26일 기록</CardTitle>
+              <CardTitle>{record.createdAt} 기록</CardTitle>
               <ChevronRightIcon width={24} height={24} strokeWidth={2} stroke={theme.color.grey_500} />
             </FlexBox>
             <FlexBox gap="6px">
-              <Styled.Chip>갑상선 기능 항진증</Styled.Chip>
-              <Styled.Chip>안양 부동시</Styled.Chip>
-              <Styled.Chip>검사</Styled.Chip>
+              {record.dxList.map(({ dxId, dxName }) => (
+                <Styled.Chip key={dxId}>{dxName}</Styled.Chip>
+              ))}
             </FlexBox>
           </Card>
           {/* TODO: 마이페이지 건강 기록장 path 연결 필요 */}


### PR DESCRIPTION
## 🛠 관련 이슈
- resolves #196 

## 📝 작업 사항
<img width="390" alt="image" src="https://github.com/healthier-devs/healthier-frontend/assets/53258214/d37b9df4-5801-4c2e-aa39-c6a1900f2ae1">

- 마이페이지에서 건강기록장 데이터를 연결했습니다.

<img width="390" alt="image" src="https://github.com/healthier-devs/healthier-frontend/assets/53258214/bb70374b-04ea-4b33-824c-1c5497628c6a">

- 메인 홈에서 건강기록장 데이터를 연결했습니다.

<img width="390" alt="image" src="https://github.com/healthier-devs/healthier-frontend/assets/53258214/a1caed7e-1ba6-47fb-9b3f-d2f1b9160fb3">

- 챌린지 상세 페이지에서 참여하기 버튼의 너비가 깨지는 문제를 해결했습니다.

- 로그아웃 시 쿼리 데이터 캐시가 남아있는 문제를 해결했습니다.