### PR TITLE
[Feat] 건강기록장 상세페이지 연결

### DIFF
--- a/src/api/diagnosis/fetcher.ts
+++ b/src/api/diagnosis/fetcher.ts
@@ -1,5 +1,9 @@
 import { createFetcher, createUnauthorizedFetcher } from "..";
-import type { IDiagnosisRecordsResponse, IDiagnosisRecordsRequest } from "src/interfaces/diagnoseApi/records";
+import type {
+  IDiagnosisRecordsResponse,
+  IDiagnosisRecordsRequest,
+  IDiagnosisRecordDetailResponse,
+} from "src/interfaces/diagnoseApi/records";
 import type { IDDXResultResponse } from "src/interfaces/diagnoseApi/result";
 import type { IDiagnosisStatisticsResponse } from "src/interfaces/diagnoseApi/statistics";
 
@@ -15,5 +19,8 @@ export const diagnosisFetcher = {
   },
   getRecords({ page, size }: IDiagnosisRecordsRequest): Promise<IDiagnosisRecordsResponse> {
     return fetcher.get(`/records?page=${page}&size=${size}`);
+  },
+  getRecordDetail(dxRecordId: string): Promise<IDiagnosisRecordDetailResponse> {
+    return fetcher.get(`/records/${dxRecordId}`);
   },
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { AxiosError } from "axios";
+import { DEVELOPMENT_SET_COOKIE_OPTIONS, ACCESS_TOKEN_AGE, REFRESH_TOKEN_AGE } from "src/data/account";
 import { setCookie, getCookie } from "src/utils/cookies";
 import type { AxiosResponse, AxiosRequestConfig } from "axios";
 
@@ -67,14 +68,12 @@ export const createFetcher = (path: string) => {
         });
 
         setCookie("accessToken", reissueResponse.data.accessToken, {
-          path: "/",
-          secure: false,
-          domain: "localhost",
+          ...DEVELOPMENT_SET_COOKIE_OPTIONS,
+          maxAge: ACCESS_TOKEN_AGE,
         });
         setCookie("refreshToken", reissueResponse.data.refreshToken, {
-          domain: "localhost",
-          path: "/",
-          secure: false, // TODO: 배포 시에는 HTTPS 설정을 위해 true로 변경
+          ...DEVELOPMENT_SET_COOKIE_OPTIONS,
+          maxAge: REFRESH_TOKEN_AGE,
         });
 
         return instance.request(_err.config);

--- a/src/data/account.ts
+++ b/src/data/account.ts
@@ -34,9 +34,21 @@ export const NICKNAME_OBJECTS = [
   "마우스",
 ];
 
-export const ACCESS_TOKEN_AGE = 60;
+export const ACCESS_TOKEN_AGE = 604800;
+export const REFRESH_TOKEN_AGE = ACCESS_TOKEN_AGE * 2;
 
 export const VERIFICATION_CODE_LENGTH = 6;
 
 export const VERIFICATION_CODE_AGE = 180;
 export const VERIFICATION_CODE_EXPIRED = 999;
+
+export const DEVELOPMENT_SET_COOKIE_OPTIONS = {
+  path: "/",
+  domain: "localhost",
+  secure: false,
+};
+
+export const DEPLOYMENT_SET_COOKIE_OPTIONS = {
+  path: "/",
+  secure: true,
+};

--- a/src/hooks/diagnosis/useGetRecordDetail.ts
+++ b/src/hooks/diagnosis/useGetRecordDetail.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { diagnosisFetcher } from "src/api/diagnosis/fetcher";
+import { queryKeys } from "src/api/queryKeys";
+import type { IDiagnosisRecordDetailResponse } from "src/interfaces/diagnoseApi/records";
+
+const DEFAULT_RECORD_DETAIL_DATA: IDiagnosisRecordDetailResponse = {
+  username: "",
+  diagnosis: [],
+};
+
+export const useGetRecordDetail = (dxRecordId: string) => {
+  const { data: recordDetailData } = useQuery({
+    queryKey: [queryKeys.DIAGNOSIS_RECORDS, dxRecordId],
+    queryFn: () => diagnosisFetcher.getRecordDetail(dxRecordId),
+    enabled: dxRecordId !== "",
+  });
+
+  return {
+    recordDetailData: recordDetailData ?? DEFAULT_RECORD_DETAIL_DATA,
+  };
+};

--- a/src/hooks/diagnosis/useGetRecords.ts
+++ b/src/hooks/diagnosis/useGetRecords.ts
@@ -15,7 +15,7 @@ export const useGetRecords = ({ size, authenticated }: { size: number } & Pick<I
     fetchNextPage,
     hasNextPage,
   } = useInfiniteQuery({
-    queryKey: [queryKeys, size],
+    queryKey: [queryKeys.DIAGNOSIS_RECORDS, size],
     queryFn: ({ pageParam = 0 }) => diagnosisFetcher.getRecords({ page: pageParam as number, size }),
     getNextPageParam: (lastPage: IDiagnosisRecordsResponse, _, lastPageParam) => {
       if (lastPage.total === 0) {

--- a/src/interfaces/diagnoseApi/records.ts
+++ b/src/interfaces/diagnoseApi/records.ts
@@ -1,3 +1,5 @@
+import type { IDiagnoseResult } from "./diagnosis";
+
 export interface IDiagnosisRecordsRequest {
   page: number;
   size: number;
@@ -8,7 +10,11 @@ interface IDX {
   dxName: string;
 }
 
-export interface IDiagnosisRecord {
+export interface IDXRecordId {
+  dxRecordId: string;
+}
+
+export interface IDiagnosisRecord extends IDXRecordId {
   createdAt: string;
   dxList: IDX[];
 }
@@ -21,4 +27,9 @@ export interface IDiagnosisRecords {
 export interface IDiagnosisRecordsResponse {
   data: IDiagnosisRecords[];
   total: number;
+}
+
+export interface IDiagnosisRecordDetailResponse {
+  username: string;
+  diagnosis: IDiagnoseResult[];
 }

--- a/src/pages/account/diagnose-record/index.style.tsx
+++ b/src/pages/account/diagnose-record/index.style.tsx
@@ -63,6 +63,7 @@ export const DiagnoseCard = styled.div`
   gap: 1.2rem;
   border-radius: 0.8rem;
   background-color: ${({ theme }) => theme.color.grey_850};
+  cursor: pointer;
   .topArea {
     display: flex;
     flex-direction: row;

--- a/src/pages/account/diagnose-record/index.tsx
+++ b/src/pages/account/diagnose-record/index.tsx
@@ -8,6 +8,7 @@ import { useAppSelector } from "src/state";
 import * as Styled from "./index.style";
 
 const DiagnoseRecord = () => {
+  const navigate = useNavigate();
   const { authenticated } = useAppSelector((state) => state.auth);
 
   const [intersectionRef, inView] = useInView();
@@ -37,8 +38,15 @@ const DiagnoseRecord = () => {
                     <Styled.Typography className="highlight">{records.length}개</Styled.Typography>의 기록
                   </Styled.Typography>
                 </Styled.MonthTitle>
-                {records.map(({ createdAt, dxList }) => (
-                  <Styled.DiagnoseCard key={createdAt}>
+                {records.map(({ createdAt, dxList, dxRecordId }) => (
+                  <Styled.DiagnoseCard
+                    key={createdAt}
+                    onClick={() =>
+                      navigate("/result-list", {
+                        state: { dxRecordId },
+                      })
+                    }
+                  >
                     <div className="topArea">
                       <Styled.Typography className="cardMainText">
                         {new Date(createdAt).getMonth() + 1}월 {new Date(createdAt).getDate()}일 증상 감별 내역

--- a/src/pages/diagnosisList/index.tsx
+++ b/src/pages/diagnosisList/index.tsx
@@ -3,13 +3,22 @@ import { useLocation, useNavigate } from "react-router-dom";
 import ContentHeader from "src/components/contentHeader";
 import DiagnosisCard from "src/components/diagnosisCard";
 import Layout from "src/components/layout";
+import { useGetRecordDetail } from "src/hooks/diagnosis/useGetRecordDetail";
 import * as Styled from "./index.style";
 import type { IDiagnoseResult } from "src/interfaces/diagnoseApi/diagnosis";
+import type { IDXRecordId } from "src/interfaces/diagnoseApi/records";
+
+const isDXRecordId = (state: IDiagnoseResult[] | IDXRecordId): state is IDXRecordId => {
+  return "dxRecordId" in state;
+};
 
 const DiagnosisList = () => {
-  const { state } = useLocation() as { state: IDiagnoseResult[] };
+  const { state } = useLocation() as { state: IDiagnoseResult[] | IDXRecordId };
   const [mostLikelyResult, setMostLikelyResult] = useState<IDiagnoseResult>();
   const [extraResults, setExtraResults] = useState<IDiagnoseResult[]>([]);
+  const [dxRecordId, setDxRecordId] = useState<string>("");
+
+  const { recordDetailData } = useGetRecordDetail(dxRecordId);
 
   const navigate = useNavigate();
 
@@ -17,10 +26,24 @@ const DiagnosisList = () => {
     if (!state) {
       navigate("/");
     }
-
-    setMostLikelyResult(state[0]);
-    setExtraResults(state.slice(1, state.length));
+    if (isDXRecordId(state)) {
+      setDxRecordId(state.dxRecordId);
+    } else {
+      setMostLikelyResult(state[0]);
+      setExtraResults(state.slice(1, state.length));
+    }
   }, [state, navigate]);
+
+  useEffect(() => {
+    const { diagnosis } = recordDetailData;
+
+    if (diagnosis.length === 0) {
+      return;
+    }
+
+    setMostLikelyResult(diagnosis[0]);
+    setExtraResults(diagnosis.slice(1, diagnosis.length));
+  }, [recordDetailData]);
 
   const handleNavigate = (dx_id: string) => {
     navigate("/result", {

--- a/src/pages/main/challenges/index.style.tsx
+++ b/src/pages/main/challenges/index.style.tsx
@@ -27,6 +27,7 @@ export const Card = styled.div`
   border-radius: 8px;
 
   background: ${({ theme }) => theme.color.grey_850};
+  cursor: pointer;
 `;
 
 export const CardTitle = styled.p`

--- a/src/pages/main/diagnosis-history/index.tsx
+++ b/src/pages/main/diagnosis-history/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { ChevronRightIcon } from "src/assets/icons/ChevronRightIcon";
 import FlexBox from "src/components/flexBox";
 import { useGetRecords } from "src/hooks/diagnosis/useGetRecords";
@@ -13,11 +14,13 @@ import type { IDiagnosisRecord } from "src/interfaces/diagnoseApi/records";
 import type { IAuthState } from "src/state";
 
 function DiagnosisHistory({ authenticated }: IAuthState) {
+  const navigate = useNavigate();
   const { recordsData } = useGetRecords({ size: 15, authenticated });
 
   const [record, setRecord] = useState<IDiagnosisRecord>({
     createdAt: "",
     dxList: [],
+    dxRecordId: "",
   });
 
   useEffect(() => {
@@ -26,11 +29,12 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
     }
 
     const latestMonthData = recordsData[0].data[0].records;
-    const { createdAt, dxList } = latestMonthData[latestMonthData.length - 1];
+    const { createdAt, dxList, dxRecordId } = latestMonthData[latestMonthData.length - 1];
 
     setRecord({
       createdAt: new Date(createdAt).getMonth() + 1 + "월 " + new Date(createdAt).getDate() + "일",
       dxList,
+      dxRecordId,
     });
   }, [recordsData]);
 
@@ -45,7 +49,15 @@ function DiagnosisHistory({ authenticated }: IAuthState) {
         />
       ) : (
         <>
-          <Card>
+          <Card
+            onClick={() =>
+              navigate("/result-list", {
+                state: {
+                  dxRecordId: record.dxRecordId,
+                },
+              })
+            }
+          >
             <FlexBox alignItems="center" justifyContent="space-between" mb="12px">
               <CardTitle>{record.createdAt} 기록</CardTitle>
               <ChevronRightIcon width={24} height={24} strokeWidth={2} stroke={theme.color.grey_500} />


### PR DESCRIPTION
## 🛠 관련 이슈
- resolves #202 

## 📝 작업 사항
<img width="390" alt="image" src="https://github.com/healthier-devs/healthier-frontend/assets/53258214/53e8d01f-2758-4575-bafc-b7940e7994c7">

- 건강기록장 레코드 클릭 시 해당 상세 기록으로 이동하도록 했습니다.