### PR TITLE
[Fix] 챌린지 화면 오류 수정

### DIFF
--- a/src/api/challenge/fetcher.ts
+++ b/src/api/challenge/fetcher.ts
@@ -24,7 +24,7 @@ export const challengeFetcher = {
     return fetcher.get("/image");
   },
   getChallengeByID({ challengeID }: { challengeID: number }): Promise<IChallengeDetailResponse> {
-    return unauthorizedFetcher.get(`${challengeID}`);
+    return fetcher.get(`${challengeID}`);
   },
   postChallengeJoin({ challengeId, isToday }: { challengeId: number; isToday: number }) {
     return fetcher.post(`/join/${challengeId}?isToday=${isToday}`);

--- a/src/hooks/challenge/useGetChallengeCategory.ts
+++ b/src/hooks/challenge/useGetChallengeCategory.ts
@@ -9,7 +9,7 @@ export const useGetChallengeCategory = () => {
     isLoading,
     isSuccess,
   } = useQuery<TChallengeCategoryListResponse>({
-    queryKey: [queryKeys.CHALLENGE],
+    queryKey: [queryKeys.CHALLENGE, "list"],
     queryFn: () => challengeFetcher.getChallengeCategory(),
   });
 

--- a/src/pages/challenge-detail/index.style.tsx
+++ b/src/pages/challenge-detail/index.style.tsx
@@ -132,15 +132,15 @@ export const ButtonWrapper = styled.div`
   background: linear-gradient(180deg, rgba(19, 20, 22, 0) 0%, rgba(19, 20, 22, 0.95) 78.12%, #131416 100%);
 `;
 
-export const Button = styled.button<{ canJoin: boolean }>`
+export const Button = styled.button`
   width: 100%;
   padding: 1.4rem 6.2rem;
 
   border-radius: 3rem;
-  background: ${({ theme, canJoin }) => (canJoin ? theme.color.blue : theme.color.grey_600)};
+  background: ${({ theme }) => theme.color.blue};
 
   font-size: 1.4rem;
-  color: ${({ theme, canJoin }) => (canJoin ? theme.color.grey_100 : theme.color.grey_500)};
+  color: ${({ theme }) => theme.color.grey_100};
   font-weight: 300;
   line-height: 150%;
 

--- a/src/pages/challenge-detail/index.style.tsx
+++ b/src/pages/challenge-detail/index.style.tsx
@@ -128,6 +128,8 @@ export const ButtonWrapper = styled.div`
   position: fixed;
   bottom: 0;
   box-sizing: border-box;
+
+  background: linear-gradient(180deg, rgba(19, 20, 22, 0) 0%, rgba(19, 20, 22, 0.95) 78.12%, #131416 100%);
 `;
 
 export const Button = styled.button<{ canJoin: boolean }>`

--- a/src/pages/challenge-detail/index.tsx
+++ b/src/pages/challenge-detail/index.tsx
@@ -110,11 +110,13 @@ const ChallengeDetail = () => {
 
   const { isLoading, challengeData } = useGetChallengeById(challengeID);
   const challenge = challengeData ? challengeData.challenge : null;
-  const canParticipate = challengeData ? challengeData.participationStatus : false;
+  const canParticipate = challengeData ? !challengeData.participationStatus : true;
 
   const handleClickParticipateButton = () => {
     if (canParticipate) {
       confirmDialogOpen();
+    } else {
+      navigate(`/challenge/stamp/${id}`);
     }
   };
 
@@ -223,9 +225,7 @@ const ChallengeDetail = () => {
         <ChallengeNotification />
       </Styled.Container>
       <Styled.ButtonWrapper>
-        <Styled.Button onClick={handleClickParticipateButton} canJoin={canParticipate}>
-          참여하기
-        </Styled.Button>
+        <Styled.Button onClick={handleClickParticipateButton}>{canParticipate ? "참여하기" : "인증하기"}</Styled.Button>
       </Styled.ButtonWrapper>
 
       {confirmDialogIsOpen && (

--- a/src/pages/challenge-detail/index.tsx
+++ b/src/pages/challenge-detail/index.tsx
@@ -135,7 +135,7 @@ const ChallengeDetail = () => {
   };
 
   return isLoading || !challenge ? (
-    <>Loading</>
+    <></>
   ) : (
     <>
       <ContentHeader back={true} exit={false} borderBottom={false} />

--- a/src/pages/main/challenges/index.tsx
+++ b/src/pages/main/challenges/index.tsx
@@ -29,7 +29,7 @@ function Challenges({ authenticated }: IAuthState) {
         ) : (
           (myChallengesData.myChallenge as IMyChallengeProgress[]).map((challenge) => (
             <Link to={`/challenge/${challenge.challengeId}`} key={challenge.challengeId}>
-              <FlexBox flexDirection="column" gap="12px">
+              <FlexBox flexDirection="column" gap="12px" mt="12px">
                 <div>
                   <Styled.Typography className="grey-300">
                     아직 <span className="highlight">오늘의 챌린지</span>를 인증하지 않았어요!

--- a/src/pages/main/lib/StartContents.tsx
+++ b/src/pages/main/lib/StartContents.tsx
@@ -25,7 +25,7 @@ function StartContents({ text, buttonText, buttonHref }: IStartContents) {
 export default StartContents;
 
 const Box = styled.div`
-  margin-top: 2px;
+  padding-top: 2px;
 
   padding: 20px;
   border-radius: 16px;

--- a/src/pages/my-challenge/index.tsx
+++ b/src/pages/my-challenge/index.tsx
@@ -30,6 +30,8 @@ function ChallengeList() {
     }
   }, [selectedTab, isReadyData, myChallengesData]);
 
+  console.log(myChallengesData?.myChallenge);
+
   return (
     <div>
       <Styled.HeaderContainer>
@@ -88,7 +90,7 @@ function ChallengeList() {
           <Styled.DescriptionText>챌린지에 대한 리워드는 선물함에서 확인 가능해요</Styled.DescriptionText>
         </Styled.CardList>
       )}
-      {isReadyData && (myChallengesData?.count ?? 0) === 0 && (
+      {(!authenticated || (isReadyData && (myChallengesData?.count ?? 0) === 0)) && (
         <Styled.EmptyContainer>
           <Styled.EmptyText>
             아직 {selectedTab === "PROGRESS" ? "도전을 시작한" : "완료한"} 챌린지가 없어요!


### PR DESCRIPTION
## 🛠 관련 이슈
- 

## 📝 작업 사항
- 챌린지 상세 api에서 participationStatus가 null로 나오는 문제를 수정했습니다 (unAuthFetcher에서 fetcher로 수정)
- participationStatus에 따라 이미 참여한 챌린지의 경우 인증 도장판으로 이동하는 로직을 추가했습니다.
- 챌린지 상세 -> 인증 도장판 -> 챌린지 목록으로 이동하는 경우 챌린지 목록 api 패칭에 오류가 생기는 문제를 수정했습니다 (query key 수정)
- 이상하게 나오는 일부 ui를 수정했습니다
