### PR TITLE
Fix/247 challenge scroll

### DIFF
--- a/src/pages/challenge-list/index.style.tsx
+++ b/src/pages/challenge-list/index.style.tsx
@@ -2,6 +2,13 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   width: 100%;
+  height: calc(100% - 56px);
+  overflow-y: hidden;
+`;
+
+export const Ghost = styled.div`
+  width: 100%;
+  height: 240px;
 `;
 
 export const HeaderContainer = styled.div`
@@ -123,4 +130,6 @@ export const CardList = styled.ul`
   gap: 1.2rem;
 
   margin: 1.2rem 2.4rem;
+  height: calc(100% - 250px);
+  overflow-y: scroll;
 `;

--- a/src/pages/challenge-list/index.tsx
+++ b/src/pages/challenge-list/index.tsx
@@ -4,6 +4,9 @@ import { useNavigate } from "react-router-dom";
 import NavigationBar from "src/components/navigationBar";
 import { useGetChallengeCategory } from "src/hooks/challenge/useGetChallengeCategory";
 import { useGetChallenges } from "src/hooks/challenge/useGetChallenges";
+import { useAppSelector } from "src/state";
+import { useAppDispatch } from "src/state";
+import { saveChallengeCategory } from "src/state/challengeSlice";
 import { IChallenge } from "../../interfaces/challenges";
 import ChallengeCard from "./challenge-card";
 import * as Styled from "./index.style";
@@ -15,8 +18,10 @@ interface IPageInfo {
 
 function ChallengeList() {
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const { challengeCategory } = useAppSelector((state) => state.challenge);
 
-  const [selectedCategory, setSelectedCategory] = useState<string>("");
+  const [selectedCategory, setSelectedCategory] = useState<string>(challengeCategory);
   const [pageInfo, setPageInfo] = useState<IPageInfo>({ page: 0, size: 15 });
   const [challengeList, setChallengeList] = useState<IChallenge[]>([]);
 
@@ -33,16 +38,19 @@ function ChallengeList() {
     setChallengeList([]);
     setPageInfo({ page: 0, size: 15 });
   }, [selectedCategory]);
+
   useEffect(() => {
     if (challengeCategoryData && !selectedCategory) {
       setSelectedCategory(challengeCategoryData[0].name);
     }
   }, [challengeCategoryData]);
+
   useEffect(() => {
     if (challengesData) {
       setChallengeList((prev) => [...prev, ...challengesData.data]);
     }
   }, [challengesData]);
+
   useEffect(() => {
     if (inView) {
       setPageInfo({ ...pageInfo, page: pageInfo.page + 1 });
@@ -61,8 +69,15 @@ function ChallengeList() {
 
       <Styled.Container>
         <Styled.Categories>
-          {challengeCategoryData?.map(({ name, koreanName }, index) => (
-            <Styled.Item key={name} isSelected={name === selectedCategory} onClick={() => setSelectedCategory(name)}>
+          {challengeCategoryData?.map(({ name, koreanName }) => (
+            <Styled.Item
+              key={name}
+              isSelected={name === selectedCategory}
+              onClick={() => {
+                setSelectedCategory(name);
+                dispatch(saveChallengeCategory({ challengeCategory: name }));
+              }}
+            >
               <Styled.ImgWrapper className="background">
                 <Styled.Img className="img" src={`/images/challenge/${name}.svg`} alt="challenge-icon" />
               </Styled.ImgWrapper>

--- a/src/state/challengeSlice.ts
+++ b/src/state/challengeSlice.ts
@@ -1,0 +1,22 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+interface IChallengeState {
+  challengeCategory: string;
+}
+
+const initialState: IChallengeState = {
+  challengeCategory: "",
+};
+
+export const challengeSlice = createSlice({
+  name: "challenge",
+  initialState,
+  reducers: {
+    saveChallengeCategory: (state, action: PayloadAction<Pick<IChallengeState, "challengeCategory">>) => {
+      state.challengeCategory = action.payload.challengeCategory;
+    },
+  },
+});
+
+export const { saveChallengeCategory } = challengeSlice.actions;
+export default challengeSlice.reducer;

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -2,6 +2,7 @@ import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { persistReducer, persistStore, FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER } from "redux-persist";
 import sessionStorage from "redux-persist/es/storage/session";
 import authReducer from "./authSlice";
+import challengeReducer from "./challengeSlice";
 import diagnoseReducer from "./diagnoseSlice";
 import userReducer from "./userSlice";
 
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   user: userReducer,
   auth: authReducer,
   diagnose: diagnoseReducer,
+  challenge: challengeReducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
## 🛠 관련 이슈
- resolves #247 

## 📝 작업 사항
- 챌린지 리스트에서 스크롤이 안되는 문제를 수정했습니다.
- 챌린지 상세 보기 후 뒤로가기를 했을 때, 카테고리가 유지되지 않는 문제에 대응했습니다.
